### PR TITLE
Implements eip-7708

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -561,6 +561,12 @@ func (c *ChainConfig) IsEIP4762(num *big.Int, time uint64) bool {
 	return c.IsVerkle(num, time)
 }
 
+// IsEIP7708 returns whether [EIP-7708](https://eips.ethereum.org/EIPS/eip-7708) has been activated at given block.
+func (c *ChainConfig) IsEIP7708(num *big.Int, time uint64) bool {
+	// TODO:Decide how to activate this EIP
+	return false
+}
+
 // CheckCompatible checks whether scheduled fork transitions have been imported
 // with a mismatching chain configuration.
 func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height uint64, time uint64) *ConfigCompatError {
@@ -894,6 +900,7 @@ type Rules struct {
 	IsBerlin, IsLondon                                      bool
 	IsMerge, IsShanghai, IsCancun, IsPrague                 bool
 	IsVerkle                                                bool
+	IsEIP7708                                               bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -924,5 +931,6 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsPrague:         isMerge && c.IsPrague(num, timestamp),
 		IsVerkle:         isVerkle,
 		IsEIP4762:        isVerkle,
+		IsEIP7708:        c.IsEIP7708(num, timestamp),
 	}
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const (
@@ -199,4 +200,11 @@ var (
 	HistoryStorageAddress = common.HexToAddress("0x0aae40965e6800cd9b1f4b05ff21581047e3f91e")
 	// HistoryStorageCode is the code with getters for historical block hashes.
 	HistoryStorageCode = common.FromHex("3373fffffffffffffffffffffffffffffffffffffffe1460575767ffffffffffffffff5f3511605357600143035f3511604b575f35612000014311604b57611fff5f3516545f5260205ff35b5f5f5260205ff35b5f5ffd5b5f35611fff60014303165500")
+)
+
+// [EIP-7708](https://eips.ethereum.org/EIPS/eip-7708) specific params
+var (
+	LogNativeTransferTopicMagic = common.BytesToHash(crypto.Keccak256([]byte("0000000000000000000000000000000000000000000000000000000000000000")))
+	// Proposed here: https://ethereum-magicians.org/t/eip-7708-eth-transfers-emit-a-log/20034/25
+	LogNativeTransferContractAddress = common.HexToAddress("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE")
 )


### PR DESCRIPTION
Implements: https://eips.ethereum.org/EIPS/eip-7708

## Open questions:
#### Missing definitions
1. `Magic` was not defined in EIP, I have set a placeholder for `Magic` as the hash of `0000...000000000` as proposed [here](https://ethereum-magicians.org/t/eip-7708-eth-transfers-emit-a-log/20034/3)
2. `Address` is also not defined in EIP, I have set placeholder `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` as proposed [here](https://ethereum-magicians.org/t/eip-7708-eth-transfers-emit-a-log/20034/15)
3. Why do we not log when `CREATE` is called?

#### "Stuff" I'm unsure about
From EIP:
> The LOG of a value-transferring transaction should be placed before any logs created by EVM execution. The other two LOGs are placed when the value transfer executes.

**Q1**
"value-transferring transaction" - is this just EOA to EOA transfer? (eg. Bob directly transferred 1 ETH to Alice)

**Q2**
This one is about adding logs in the proper place. 
I _think_ I placed `SELF_DESTRUCT` appropriately. But I'm unsure about handling `CALL` and "value-transferring tx"

This is my understanding of transaction execution flow:

![Tx Execution Diagram](https://github.com/user-attachments/assets/ac1a726b-b621-4c8b-a694-e11b9bbb0474)
