### PR TITLE
[P2] Implements RIP-7728

### DIFF
--- a/core/vm/contracts_rollup.go
+++ b/core/vm/contracts_rollup.go
@@ -100,7 +100,7 @@ func (c *L1SLoad) Run(input []byte) ([]byte, error) {
 		ctx = context.Background()
 	}
 
-	res, err := c.L1RpcClient.StorageAt(ctx, contractAddress, contractStorageKeys[0], c.GetLatestL1BlockNumber())
+	res, err := c.L1RpcClient.StoragesAt(ctx, contractAddress, contractStorageKeys, c.GetLatestL1BlockNumber())
 	if err != nil {
 		return nil, err
 	}

--- a/core/vm/contracts_rollup.go
+++ b/core/vm/contracts_rollup.go
@@ -78,7 +78,7 @@ func (c *L1SLoad) Run(input []byte) ([]byte, error) {
 	thereIsAtLeast1StorageKeyToRead := countOfStorageKeysToRead > 0
 	allStorageKeysAreExactly32Bytes := countOfStorageKeysToRead*common.HashLength == len(input)-common.AddressLength
 
-	if inputIsValid := thereIsAtLeast1StorageKeyToRead && allStorageKeysAreExactly32Bytes; !inputIsValid {
+	if inputIsInvalid := !(thereIsAtLeast1StorageKeyToRead && allStorageKeysAreExactly32Bytes); inputIsInvalid {
 		return nil, errors.New("L1SLOAD input is malformed")
 	}
 

--- a/core/vm/contracts_rollup.go
+++ b/core/vm/contracts_rollup.go
@@ -89,8 +89,6 @@ func (c *L1SLoad) Run(input []byte) ([]byte, error) {
 		contractStorageKeys[k] = common.BytesToHash(input[k*common.HashLength : (k+1)*common.HashLength])
 	}
 
-	// TODO:
-	// 1. Batch multiple storage slots
 	var ctx context.Context
 	if params.L1SLoadRPCTimeoutInSec > 0 {
 		c, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(params.L1SLoadRPCTimeoutInSec))

--- a/core/vm/contracts_rollup.go
+++ b/core/vm/contracts_rollup.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -90,8 +91,16 @@ func (c *L1SLoad) Run(input []byte) ([]byte, error) {
 
 	// TODO:
 	// 1. Batch multiple storage slots
-	// 2. What about timeout strategy here?
-	res, err := c.L1RpcClient.StorageAt(context.Background(), contractAddress, contractStorageKeys[0], c.GetLatestL1BlockNumber())
+	var ctx context.Context
+	if params.L1SLoadRPCTimeoutInSec > 0 {
+		c, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(params.L1SLoadRPCTimeoutInSec))
+		ctx = c
+		defer cancel()
+	} else {
+		ctx = context.Background()
+	}
+
+	res, err := c.L1RpcClient.StorageAt(ctx, contractAddress, contractStorageKeys[0], c.GetLatestL1BlockNumber())
 	if err != nil {
 		return nil, err
 	}

--- a/core/vm/contracts_rollup.go
+++ b/core/vm/contracts_rollup.go
@@ -4,27 +4,23 @@
 package vm
 
 import (
+	"context"
 	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
-
-type RollupPrecompiledContractsOverrides struct {
-	l1SLoadGetLatestL1Block func() *big.Int
-}
-
-func GenerateRollupPrecompiledContractsOverrides(evm *EVM) RollupPrecompiledContractsOverrides {
-	return RollupPrecompiledContractsOverrides{
-		l1SLoadGetLatestL1Block: getLatestL1BlockNumber(evm),
-	}
-}
 
 var rollupL1SloadAddress = common.BytesToAddress([]byte{0x10, 0x01})
 
 var PrecompiledContractsRollupR0 = PrecompiledContracts{
-	rollupL1SloadAddress: &l1SLoad{},
+	rollupL1SloadAddress: &L1SLoad{},
+}
+
+type RollupPrecompileActivationConfig struct {
+	L1SLoad
 }
 
 func activeRollupPrecompiledContracts(rules params.Rules) PrecompiledContracts {
@@ -36,40 +32,85 @@ func activeRollupPrecompiledContracts(rules params.Rules) PrecompiledContracts {
 	}
 }
 
-func (evm *EVM) activateRollupPrecompiledContracts() {
-	activeRollupPrecompiles := activeRollupPrecompiledContracts(evm.chainRules)
-	for k, v := range activeRollupPrecompiles {
-		evm.precompiles[k] = v
-	}
-
+func (pc *PrecompiledContracts) ActivateRollupPrecompiledContracts(config RollupPrecompileActivationConfig) {
 	// NOTE: if L1SLoad was not activated via chain rules this is no-op
-	evm.precompiles.activateL1SLoad(evm.Config.L1RpcClient, evm.rollupPrecompileOverrides.l1SLoadGetLatestL1Block)
+	pc.activateL1SLoad(config.L1RpcClient, config.GetLatestL1BlockNumber)
 }
 
-type l1SLoad struct {
-	l1RpcClient            L1Client
-	getLatestL1BlockNumber func() *big.Int
+func (evm *EVM) activateRollupPrecompiledContracts() {
+	evm.precompiles.ActivateRollupPrecompiledContracts(RollupPrecompileActivationConfig{
+		L1SLoad{L1RpcClient: evm.Config.L1RpcClient, GetLatestL1BlockNumber: evm.rollupPrecompileOverrides.l1SLoadGetLatestL1Block},
+	})
 }
 
-func (c *l1SLoad) RequiredGas(input []byte) uint64 { return 0 }
+//INPUT SPECS:
+//Byte range          Name              Description
+//------------------------------------------------------------
+//[0: 19] (20 bytes)	address	          The contract address
+//[20: 51] (32 bytes)	key1	            The storage key
+//...	...	...
+//[k*32-12: k*32+19]  (32 bytes)	key_k	The storage key
 
-func (c *l1SLoad) Run(input []byte) ([]byte, error) {
+type L1SLoad struct {
+	L1RpcClient            L1RpcClient
+	GetLatestL1BlockNumber func() *big.Int
+}
+
+func (c *L1SLoad) RequiredGas(input []byte) uint64 {
+	storageSlotsToLoad := len(input[common.AddressLength-1:]) / common.HashLength
+	storageSlotsToLoad = min(storageSlotsToLoad, params.L1SLoadMaxNumStorageSlots)
+
+	return params.L1SLoadBaseGas + uint64(storageSlotsToLoad)*params.L1SLoadPerLoadGas
+}
+
+func (c *L1SLoad) Run(input []byte) ([]byte, error) {
 	if !c.isL1SLoadActive() {
-		return nil, errors.New("L1SLoad precompile not active")
+		log.Error("L1SLOAD called, but not activated", "client", c.L1RpcClient, "and latest block number function", c.GetLatestL1BlockNumber)
+		return nil, errors.New("L1SLOAD precompile not active")
 	}
 
-	return nil, nil
+	if len(input) < common.AddressLength+common.HashLength {
+		return nil, errors.New("L1SLOAD input too short")
+	}
+
+	countOfStorageKeysToRead := (len(input) - common.AddressLength) / common.HashLength
+	thereIsAtLeast1StorageKeyToRead := countOfStorageKeysToRead > 0
+	allStorageKeysAreExactly32Bytes := countOfStorageKeysToRead*common.HashLength == len(input)-common.AddressLength
+
+	if inputIsValid := thereIsAtLeast1StorageKeyToRead && allStorageKeysAreExactly32Bytes; !inputIsValid {
+		return nil, errors.New("L1SLOAD input is malformed")
+	}
+
+	contractAddress := common.BytesToAddress(input[:common.AddressLength])
+	input = input[common.AddressLength-1:]
+	contractStorageKeys := make([]common.Hash, countOfStorageKeysToRead)
+	for k := 0; k < countOfStorageKeysToRead; k++ {
+		contractStorageKeys[k] = common.BytesToHash(input[k*common.HashLength : (k+1)*common.HashLength])
+	}
+
+	// TODO:
+	// 1. Batch multiple storage slots
+	// 2. What about timeout strategy here?
+	res, err := c.L1RpcClient.StorageAt(context.Background(), contractAddress, contractStorageKeys[0], c.GetLatestL1BlockNumber())
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
-func (c *l1SLoad) isL1SLoadActive() bool {
-	return c.getLatestL1BlockNumber != nil && c.l1RpcClient != nil
+func (c *L1SLoad) isL1SLoadActive() bool {
+	return c.GetLatestL1BlockNumber != nil && c.L1RpcClient != nil
 }
 
-func (pc *PrecompiledContracts) activateL1SLoad(l1RpcClient L1Client, getLatestL1BlockNumber func() *big.Int) {
-	if (*pc)[rollupL1SloadAddress] != nil {
-		(*pc)[rollupL1SloadAddress] = &l1SLoad{
-			l1RpcClient:            l1RpcClient,
-			getLatestL1BlockNumber: getLatestL1BlockNumber,
+func (pc PrecompiledContracts) activateL1SLoad(l1RpcClient L1RpcClient, getLatestL1BlockNumber func() *big.Int) {
+	rulesSayContractShouldBeActive := pc[rollupL1SloadAddress] != nil
+	paramsNotNil := l1RpcClient != nil && getLatestL1BlockNumber != nil
+
+	if shouldActivateL1SLoad := rulesSayContractShouldBeActive && paramsNotNil; shouldActivateL1SLoad {
+		pc[rollupL1SloadAddress] = &L1SLoad{
+			L1RpcClient:            l1RpcClient,
+			GetLatestL1BlockNumber: getLatestL1BlockNumber,
 		}
 	}
 }

--- a/core/vm/contracts_rollup_overrides.go
+++ b/core/vm/contracts_rollup_overrides.go
@@ -3,9 +3,7 @@
 
 package vm
 
-import (
-	"math/big"
-)
+import "math/big"
 
 type RollupPrecompiledContractsOverrides struct {
 	l1SLoadGetLatestL1Block func() *big.Int
@@ -25,16 +23,3 @@ func getLatestL1BlockNumber(evm *EVM) func() *big.Int {
 		return evm.Context.BlockNumber
 	}
 }
-
-// [OVERRIDE]  getLatestL1BlockNumber
-// Each rollup should override this function so that it returns
-// correct latest L1 block number
-//
-// EXAMPLE 2
-// func getLatestL1BlockNumber(evm *EVM) func() *big.Int {
-// 	return func() *big.Int {
-// 		addressOfL1BlockContract := common.Address{}
-// 		slotInContractRepresentingL1BlockNumber := common.Hash{}
-// 		return evm.StateDB.GetState(addressOfL1BlockContract, slotInContractRepresentingL1BlockNumber).Big()
-// 	}
-// }

--- a/core/vm/contracts_rollup_test.go
+++ b/core/vm/contracts_rollup_test.go
@@ -10,8 +10,15 @@ import (
 
 type MockL1RPCClient struct{}
 
-func (m MockL1RPCClient) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
-	return common.Hex2Bytes("abab"), nil
+func (m MockL1RPCClient) StoragesAt(ctx context.Context, account common.Address, keys []common.Hash, blockNumber *big.Int) ([]byte, error) {
+	// testcase is in format "abab", this makes output lenght 2 bytes
+	const mockedRespValueSize = 2
+	mockResp := make([]byte, mockedRespValueSize*len(keys))
+	for i := range keys {
+		copy(mockResp[mockedRespValueSize*i:], common.Hex2Bytes("abab"))
+	}
+
+	return mockResp, nil
 }
 
 func TestPrecompiledL1SLOAD(t *testing.T) {
@@ -20,13 +27,6 @@ func TestPrecompiledL1SLOAD(t *testing.T) {
 	allPrecompiles[rollupL1SloadAddress] = &L1SLoad{}
 	allPrecompiles.activateL1SLoad(mockL1RPCClient, func() *big.Int { return big1 })
 
-	l1SLoadTestcase := precompiledTest{
-		Name:        "L1SLOAD",
-		Input:       "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc22d2c7bb6fc06067df8b0223aec460d1ebb51febb9012bc2554141a4dca08e864",
-		Expected:    "abab",
-		Gas:         4000,
-		NoBenchmark: true,
-	}
-
-	testPrecompiled(rollupL1SloadAddress.Hex(), l1SLoadTestcase, t)
+	testJson("l1sload", rollupL1SloadAddress.Hex(), t)
+	testJsonFail("l1sload", rollupL1SloadAddress.Hex(), t)
 }

--- a/core/vm/contracts_rollup_test.go
+++ b/core/vm/contracts_rollup_test.go
@@ -1,0 +1,32 @@
+package vm
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type MockL1RPCClient struct{}
+
+func (m MockL1RPCClient) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
+	return common.Hex2Bytes("abab"), nil
+}
+
+func TestPrecompiledL1SLOAD(t *testing.T) {
+	mockL1RPCClient := MockL1RPCClient{}
+
+	allPrecompiles[rollupL1SloadAddress] = &L1SLoad{}
+	allPrecompiles.activateL1SLoad(mockL1RPCClient, func() *big.Int { return big1 })
+
+	l1SLoadTestcase := precompiledTest{
+		Name:        "L1SLOAD",
+		Input:       "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc22d2c7bb6fc06067df8b0223aec460d1ebb51febb9012bc2554141a4dca08e864",
+		Expected:    "abab",
+		Gas:         4000,
+		NoBenchmark: true,
+	}
+
+	testPrecompiled(rollupL1SloadAddress.Hex(), l1SLoadTestcase, t)
+}

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -45,7 +45,7 @@ type precompiledFailureTest struct {
 
 // allPrecompiles does not map to the actual set of precompiles, as it also contains
 // repriced versions of precompiles at certain slots
-var allPrecompiles = map[common.Address]PrecompiledContract{
+var allPrecompiles = PrecompiledContracts{
 	common.BytesToAddress([]byte{1}):    &ecrecover{},
 	common.BytesToAddress([]byte{2}):    &sha256hash{},
 	common.BytesToAddress([]byte{3}):    &ripemd160hash{},
@@ -181,7 +181,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 		// Keep it as uint64, multiply 100 to get two digit float later
 		mgasps := (100 * 1000 * gasUsed) / elapsed
 		bench.ReportMetric(float64(mgasps)/100, "mgas/s")
-		//Check if it is correct
+		// Check if it is correct
 		if err != nil {
 			bench.Error(err)
 			return

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -42,7 +42,7 @@ type Config struct {
 
 // [rollup-geth]
 type L1RpcClient interface {
-	StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error)
+	StoragesAt(ctx context.Context, account common.Address, keys []common.Hash, blockNumber *big.Int) ([]byte, error)
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/core/vm/testdata/precompiles/fail-l1sload.json
+++ b/core/vm/testdata/precompiles/fail-l1sload.json
@@ -12,5 +12,13 @@
     "ExpectedError": "L1SLOAD input is malformed",
     "Gas": 4000,
     "NoBenchmark": true
+  },
+  {
+    "Name": "L1SLOAD FAIL: input too long",
+    "Input": "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc22d2c7bb6fc06067df8b0223aec460d1ebb51febb9012bc2554141a4dca08e8640112d016b65e9c617ad9ab60604f772a3620177bada4cdc773d9b6a982d3c2a7a112d016b65e9c617ad9ab60604f772a3620177bada4cdc773d9b6a982d3c2a7a112d016b65e9c617ad9ab60604f772a3620177bada4cdc773d9b6a982d3c2a7a112d016b65e9c617ad9ab60604f772a3620177bada4cdc773d9b6a982d3c2a7aa83114A443dA1CecEFC50368531cACE9F37fCCcb112d016b65e9c617ad9ab60604f772a3620177bada4cdc773d9b6a982d3c2a7122",
+    "ExpectedError": "L1SLOAD input is malformed",
+    "Gas": 4000,
+    "NoBenchmark": true
   }
+
 ]

--- a/core/vm/testdata/precompiles/fail-l1sload.json
+++ b/core/vm/testdata/precompiles/fail-l1sload.json
@@ -1,0 +1,16 @@
+[
+  {
+    "Name": "L1SLOAD FAIL: input contains only address",
+    "Input": "a83114A443dA1CecEFC50368531cACE9F37fCCcb",
+    "ExpectedError": "L1SLOAD input too short",
+    "Gas": 4000,
+    "NoBenchmark": true
+  },
+  {
+    "Name": "L1SLOAD FAIL: input key not 32 bytes",
+    "Input": "a83114A443dA1CecEFC50368531cACE9F37fCCcb112d016b65e9c617ad9ab60604f772a3620177bada4cdc773d9b6a982d3c2a7122",
+    "ExpectedError": "L1SLOAD input is malformed",
+    "Gas": 4000,
+    "NoBenchmark": true
+  }
+]

--- a/core/vm/testdata/precompiles/l1sload.json
+++ b/core/vm/testdata/precompiles/l1sload.json
@@ -1,0 +1,24 @@
+[
+  {
+    "Name": "L1SLOAD: 1 key",
+    "Input": "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc22d2c7bb6fc06067df8b0223aec460d1ebb51febb9012bc2554141a4dca08e864",
+    "Expected": "abab",
+    "Gas": 4000,
+    "NoBenchmark": true
+  },
+  {
+    "Name": "L1SLOAD: 2 keys",
+    "Input": "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc22d2c7bb6fc06067df8b0223aec460d1ebb51febb9012bc2554141a4dca08e8640112d016b65e9c617ad9ab60604f772a3620177bada4cdc773d9b6a982d3c2a7a",
+    "Expected": "abababab",
+    "Gas": 6000,
+    "NoBenchmark": true
+  },
+
+  {
+    "Name": "L1SLOAD: 5 keys",
+    "Input": "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc22d2c7bb6fc06067df8b0223aec460d1ebb51febb9012bc2554141a4dca08e8640112d016b65e9c617ad9ab60604f772a3620177bada4cdc773d9b6a982d3c2a7a112d016b65e9c617ad9ab60604f772a3620177bada4cdc773d9b6a982d3c2a7a112d016b65e9c617ad9ab60604f772a3620177bada4cdc773d9b6a982d3c2a7a112d016b65e9c617ad9ab60604f772a3620177bada4cdc773d9b6a982d3c2a7a",
+    "Expected": "abababababababababab",
+    "Gas": 12000,
+    "NoBenchmark": true
+  }
+]

--- a/eth/tracers/api_rollup_test.go
+++ b/eth/tracers/api_rollup_test.go
@@ -1,0 +1,7 @@
+package tracers
+
+import "github.com/ethereum/go-ethereum/core/vm"
+
+func (b *testBackend) GetL1RpcClient() vm.L1RpcClient {
+	return nil
+}

--- a/ethclient/ethclient_rollup.go
+++ b/ethclient/ethclient_rollup.go
@@ -1,0 +1,38 @@
+package ethclient
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// StoragesAt returns the values of keys in the contract storage of the given account.
+// The block number can be nil, in which case the value is taken from the latest known block.
+func (ec *Client) StoragesAt(ctx context.Context, account common.Address, keys []common.Hash, blockNumber *big.Int) ([]byte, error) {
+	results := make([]hexutil.Bytes, len(keys))
+	reqs := make([]rpc.BatchElem, len(keys))
+
+	for i := range reqs {
+		reqs[i] = rpc.BatchElem{
+			Method: "eth_getStorageAt",
+			Args:   []interface{}{account, keys[i], toBlockNumArg(blockNumber)},
+			Result: &results[i],
+		}
+	}
+	if err := ec.c.BatchCallContext(ctx, reqs); err != nil {
+		return nil, err
+	}
+
+	output := make([]byte, common.HashLength*len(keys))
+	for i := range reqs {
+		if reqs[i].Error != nil {
+			return nil, reqs[i].Error
+		}
+		copy(output[i*common.HashLength:], results[i])
+	}
+
+	return output, nil
+}

--- a/internal/ethapi/api_rollup_test.go
+++ b/internal/ethapi/api_rollup_test.go
@@ -1,0 +1,7 @@
+package ethapi
+
+import "github.com/ethereum/go-ethereum/core/vm"
+
+func (b *testBackend) GetL1RpcClient() vm.L1RpcClient {
+	return nil
+}

--- a/internal/ethapi/transaction_args_rollup_test.go
+++ b/internal/ethapi/transaction_args_rollup_test.go
@@ -1,0 +1,7 @@
+package ethapi
+
+import "github.com/ethereum/go-ethereum/core/vm"
+
+func (b *backendMock) GetL1RpcClient() vm.L1RpcClient {
+	return nil
+}

--- a/params/protocol_params_rollup.go
+++ b/params/protocol_params_rollup.go
@@ -1,0 +1,7 @@
+package params
+
+const (
+	L1SLoadBaseGas            uint64 = 2000 // Base price for L1Sload
+	L1SLoadPerLoadGas         uint64 = 2000 // Per-load price for loading one storage slot
+	L1SLoadMaxNumStorageSlots        = 5    // Max number of storage slots requested in L1Sload precompile
+)

--- a/params/protocol_params_rollup.go
+++ b/params/protocol_params_rollup.go
@@ -4,6 +4,5 @@ const (
 	L1SLoadBaseGas            uint64 = 2000 // Base price for L1Sload
 	L1SLoadPerLoadGas         uint64 = 2000 // Per-load price for loading one storage slot
 	L1SLoadMaxNumStorageSlots        = 5    // Max number of storage slots requested in L1Sload precompile
+	L1SLoadRPCTimeoutInSec           = 3
 )
-
-var L1SLoadRPCTimeoutInSec = MainnetChainConfig.Clique.Period // After how many ms will RPC call timeout

--- a/params/protocol_params_rollup.go
+++ b/params/protocol_params_rollup.go
@@ -5,3 +5,5 @@ const (
 	L1SLoadPerLoadGas         uint64 = 2000 // Per-load price for loading one storage slot
 	L1SLoadMaxNumStorageSlots        = 5    // Max number of storage slots requested in L1Sload precompile
 )
+
+var L1SLoadRPCTimeoutInSec = MainnetChainConfig.Clique.Period // After how many ms will RPC call timeout


### PR DESCRIPTION
Actual [L1SLOAD](https://github.com/ethereum/RIPs/blob/d75e5bb4cd4a3a642090ba15249c11bfccb064db/RIPS/rip-7728.md) precompile implementation

I think the PR is self-explanatory, I'm most interested in the feedback on the code style.
I like long descriptive names because, IMO, it makes reading code so much easier, [but that's not in the Go's spirit](https://google.github.io/styleguide/go/decisions#variable-names) here is a concrete example:

```Go
countOfStorageKeysToRead:= (len(input) - common.AddressLength) / common.HashLength
thereIsAtLeast1StorageKeyToRead := countOfStorageKeysToRead > 0
allStorageKeysAreExactly32Bytes := countOfStorageKeysToRead*common.HashLength == len(input)-common.AddressLength

if inputIsInvalid := !(thereIsAtLeast1StorageKeyToRead && allStorageKeysAreExactly32Bytes); inputIsInvalid {
    return nil, errors.New("L1SLOAD input is malformed")
}
```
As you can see, this is much more verbose than what we have in the `geth` code and what the Go styling guide suggests. 
Still, I don't see downsides to writing code like this, only upsides - it will be much easier to review, understand and onboard.