### PR TITLE
[EIP-7706] Block header 

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -78,9 +78,12 @@ type ExecutableData struct {
 	ExcessBlobGas    *uint64                 `json:"excessBlobGas"`
 	Deposits         types.Deposits          `json:"depositRequests"`
 	ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
+
+	//TODO:: [rollup-geth] Add EIP-7706 specific fields
 }
 
 // JSON type overrides for executableData.
+// TODO:: [rollup-geth] Add EIP-7706 specific fields
 type executableDataMarshaling struct {
 	Number        hexutil.Uint64
 	GasLimit      hexutil.Uint64
@@ -218,6 +221,7 @@ func ExecutableDataToBlock(data ExecutableData, versionedHashes []common.Hash, b
 	return block, nil
 }
 
+// TODO: [rollup-geth] Add EIP-7706 fields
 // ExecutableDataToBlockNoHash is analogous to ExecutableDataToBlock, but is used
 // for stateless execution, so it skips checking if the executable data hashes to
 // the requested hash (stateless has to *compute* the root hash, it's not given).
@@ -297,6 +301,7 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 		nil
 }
 
+// TODO: [rollup-geth] Add EIP-7706 fields
 // BlockToExecutableData constructs the ExecutableData structure by filling the
 // fields from the given block. It assumes the given block is post-merge block.
 func BlockToExecutableData(block *types.Block, fees *big.Int, sidecars []*types.BlobTxSidecar) *ExecutionPayloadEnvelope {

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -97,6 +97,8 @@ type stEnv struct {
 	ParentExcessBlobGas   *uint64                             `json:"parentExcessBlobGas,omitempty"`
 	ParentBlobGasUsed     *uint64                             `json:"parentBlobGasUsed,omitempty"`
 	ParentBeaconBlockRoot *common.Hash                        `json:"parentBeaconBlockRoot"`
+
+	//TODO: [rollup-geh] what about EIP-7706 fields
 }
 
 type stEnvMarshaling struct {

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -219,7 +219,9 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 			rejectedTxs = append(rejectedTxs, &rejectedTx{i, errMsg})
 			continue
 		}
-		msg, err := core.TransactionToMessage(tx, signer, pre.Env.BaseFee)
+
+		//[rollup-geth] EIP-7706
+		msg, err := core.TransactionToMessageEIP4844(tx, signer, pre.Env.BaseFee)
 		if err != nil {
 			log.Warn("rejected tx", "index", i, "hash", tx.Hash(), "error", err)
 			rejectedTxs = append(rejectedTxs, &rejectedTx{i, err.Error()})

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -285,6 +285,9 @@ func applyCancunChecks(env *stEnv, chainConfig *params.ChainConfig) error {
 	return nil
 }
 
+// TODO: [rollup-geth] implement this
+func applyEIP7706Checks(env *stEnv, chainConfig *params.ChainConfig) error { return nil }
+
 type Alloc map[common.Address]types.Account
 
 func (g Alloc) OnRoot(common.Hash) {}

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip7706"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -290,6 +291,25 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 			return err
 		}
 	}
+
+	if chain.Config().IsEIP7706(header.Number, header.Time) {
+		if err := eip7706.VerifyEIP7706Header(parent, header); err != nil {
+			return err
+		}
+	} else {
+		// make sure that EIP-7706 specific fields are not present on non EIP-7706 blocks
+		switch {
+		case header.ExcessGas != nil:
+			return fmt.Errorf("invalid excessGas: have %v, expected nil", header.ExcessGas)
+		case header.GasUsedVector != nil:
+			return fmt.Errorf("invalid gasUsedVector: have %v, expected nil", header.GasUsedVector)
+		case header.GasLimits != nil:
+			return fmt.Errorf("invalid gasLimits: have %v, expected nil", header.GasLimits)
+		case header.BaseFees != nil:
+			return fmt.Errorf("invalid baseFees: have %v, expected nil", header.BaseFees)
+		}
+	}
+
 	return nil
 }
 

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	minBlobGasPrice            = big.NewInt(params.BlobTxMinBlobGasprice)
+	minBlobGasPrice            = big.NewInt(params.TxMinGasPrice)
 	blobGaspriceUpdateFraction = big.NewInt(params.BlobTxBlobGaspriceUpdateFraction)
 )
 

--- a/consensus/misc/eip7706/eip7706.go
+++ b/consensus/misc/eip7706/eip7706.go
@@ -42,6 +42,10 @@ func CalcBaseFees(parentExecGas, parentGasLimits types.VectorGasLimit) types.Vec
 func getBlockTargets(parentGasLimits types.VectorGasLimit) types.VectorGasLimit {
 	var targets types.VectorGasLimit
 	for i, limit := range parentGasLimits {
+		if params.LimitTargetRatios[i] == 0 {
+			targets[i] = 0
+			continue
+		}
 		targets[i] = limit / params.LimitTargetRatios[i]
 	}
 

--- a/consensus/misc/eip7706/eip7706.go
+++ b/consensus/misc/eip7706/eip7706.go
@@ -88,7 +88,7 @@ func SanitizeEIP7706Fields(header *types.Header) (types.VectorGasLimit, types.Ve
 		return gasUsed, excessGas, gasLimits
 	}
 
-	return *header.GasUsedVector, *header.ExcessGas, *header.GasLimits
+	return header.GasUsedVector, header.ExcessGas, header.GasLimits
 }
 
 // CalcBaseFeesFromParentHeader calculates base fees per EIP-7706 given parent header
@@ -105,7 +105,7 @@ func CalcBaseFeesFromParentHeader(config *params.ChainConfig, parent *types.Head
 		return nil, err
 	}
 
-	baseFees := CalcBaseFees(*parent.ExcessGas, *parent.GasLimits)
+	baseFees := CalcBaseFees(parent.ExcessGas, parent.GasLimits)
 
 	return &baseFees, nil
 }

--- a/consensus/misc/eip7706/eip7706.go
+++ b/consensus/misc/eip7706/eip7706.go
@@ -112,7 +112,7 @@ func CalcBaseFeesFromParentHeader(config *params.ChainConfig, parent *types.Head
 
 // CalcBaseFees  calculates vector of the base fees for current block header given parent excess gas and targets
 func CalcBaseFees(parentExecGas, parentGasLimits types.VectorGasLimit) types.VectorFeeBigint {
-	baseFees := types.NewVectorFeeBigInt()
+	baseFees := make(types.VectorFeeBigint, types.VectorFeeTypesCount)
 	targets := getBlockTargets(parentGasLimits)
 
 	for i, execGas := range parentExecGas {
@@ -138,7 +138,7 @@ func CalcExecGas(parentGasUsed, parentExecGas, parentGasLimits types.VectorGasLi
 }
 
 func getBlockTargets(parentGasLimits types.VectorGasLimit) types.VectorGasLimit {
-	var targets types.VectorGasLimit
+	targets := make(types.VectorGasLimit, types.VectorFeeTypesCount)
 	for i, limit := range parentGasLimits {
 		if params.LimitTargetRatios[i] == 0 {
 			targets[i] = 0

--- a/consensus/misc/eip7706/eip7706.go
+++ b/consensus/misc/eip7706/eip7706.go
@@ -1,0 +1,66 @@
+package eip7706
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	minTxGasPrice          = big.NewInt(params.TxMinGasPrice)
+	gaspriceUpdateFraction = big.NewInt(params.BaseFeeUpdateFraction)
+)
+
+// TODO: [rollup-geth] implement this
+// VerifyEIP7706Header Verifies EIP-7706 header
+func VerifyEIP7706Header(parent, header *types.Header) error {
+	return nil
+}
+
+// CalcExecGas calculates excess gas given parent block gas usage and target parent target gas usage
+func CalcExecGas(parentGasUsed, parentExecGas, parentGasLimits types.VectorGasLimit) types.VectorGasLimit {
+	excessGas := parentExecGas.VectorAdd(parentGasUsed)
+
+	return excessGas.VectorSubtractClampAtZero(getBlockTargets(parentGasLimits))
+}
+
+// CalcBaseFees  calculates vector of the base fees for current block header given parent excess gas and targets
+func CalcBaseFees(parentExecGas, parentGasLimits types.VectorGasLimit) types.VectorFeeBigint {
+	baseFees := types.NewVectorFeeBigInt()
+	targets := getBlockTargets(parentGasLimits)
+
+	for i, execGas := range parentExecGas {
+		target := big.NewInt(int64(targets[i]))
+		target = target.Mul(target, gaspriceUpdateFraction)
+		baseFees[i] = fakeExponential(minTxGasPrice, big.NewInt(int64(execGas)), target)
+	}
+
+	return baseFees
+}
+
+func getBlockTargets(parentGasLimits types.VectorGasLimit) types.VectorGasLimit {
+	var targets types.VectorGasLimit
+	for i, limit := range parentGasLimits {
+		targets[i] = limit / params.LimitTargetRatios[i]
+	}
+
+	return targets
+}
+
+// fakeExponential approximates factor * e ** (numerator / denominator) using
+// Taylor expansion.
+func fakeExponential(factor, numerator, denominator *big.Int) *big.Int {
+	var (
+		output = new(big.Int)
+		accum  = new(big.Int).Mul(factor, denominator)
+	)
+	for i := 1; accum.Sign() > 0; i++ {
+		output.Add(output, accum)
+
+		accum.Mul(accum, numerator)
+		accum.Div(accum, denominator)
+		accum.Div(accum, big.NewInt(int64(i)))
+	}
+	return output.Div(output, denominator)
+}

--- a/consensus/misc/eip7706/eip7706_test.go
+++ b/consensus/misc/eip7706/eip7706_test.go
@@ -3,6 +3,7 @@ package eip7706
 import (
 	"math/big"
 	"regexp"
+	"slices"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -46,7 +47,7 @@ func TestGetBlockTargets(t *testing.T) {
 		params.LimitTargetRatios = tt.limitTargetRatios // Set the ratios for the test
 		got := getBlockTargets(tt.parentGasLimits)
 
-		if got != tt.want {
+		if !slices.Equal(tt.want, got) {
 			t.Errorf("test %d: getBlockTargets(%v) = %v; want %v",
 				i, tt.parentGasLimits, got, tt.want)
 		}
@@ -89,7 +90,7 @@ func TestCalcExecGas(t *testing.T) {
 	for i, tt := range tests {
 		got := CalcExecGas(tt.parentGasUsed, tt.parentExecGas, tt.parentGasLimits)
 
-		if got != tt.want {
+		if !slices.Equal(tt.want, got) {
 			t.Errorf("test %d: CalcExecGas(%v, %v, %v) = %v; want %v",
 				i, tt.parentGasUsed, tt.parentExecGas, tt.parentGasLimits, got, tt.want)
 		}
@@ -164,9 +165,9 @@ func TestVerifyEIP7706Header(t *testing.T) {
 	// Helper function to create a default header.
 	defaultHeader := func() *types.Header {
 		header := &types.Header{
-			GasLimits:     &types.VectorGasLimit{params.GenesisGasLimit, params.MaxBlobGasPerBlock, params.GenesisGasLimit / params.CallDataGasLimitRatio},
-			GasUsedVector: &types.VectorGasLimit{0, 0, 0},
-			ExcessGas:     &types.VectorGasLimit{0, 0, 0},
+			GasLimits:     types.VectorGasLimit{params.GenesisGasLimit, params.MaxBlobGasPerBlock, params.GenesisGasLimit / params.CallDataGasLimitRatio},
+			GasUsedVector: types.VectorGasLimit{0, 0, 0},
+			ExcessGas:     types.VectorGasLimit{0, 0, 0},
 			// BaseFees are optional and can be set for testing.
 			BaseFees: nil,
 		}
@@ -194,9 +195,9 @@ func TestVerifyEIP7706Header(t *testing.T) {
 	// Helper function to create a parent header that is an EIP-7706 block.
 	eip7706Parent := func() *types.Header {
 		parent := &types.Header{
-			GasLimits:     &types.VectorGasLimit{params.GenesisGasLimit, params.MaxBlobGasPerBlock, params.GenesisGasLimit / params.CallDataGasLimitRatio},
-			GasUsedVector: &types.VectorGasLimit{0, 0, 0},
-			ExcessGas:     &types.VectorGasLimit{0, 0, 0},
+			GasLimits:     types.VectorGasLimit{params.GenesisGasLimit, params.MaxBlobGasPerBlock, params.GenesisGasLimit / params.CallDataGasLimitRatio},
+			GasUsedVector: types.VectorGasLimit{0, 0, 0},
+			ExcessGas:     types.VectorGasLimit{0, 0, 0},
 			BaseFees:      nil,
 			Number:        big.NewInt(1),
 		}
@@ -306,7 +307,7 @@ func TestVerifyEIP7706Header(t *testing.T) {
 			header: func() *types.Header {
 				h := defaultHeader()
 				// Set incorrect BaseFees for testing.
-				h.BaseFees = &types.VectorFeeBigint{big.NewInt(0), big.NewInt(1), big.NewInt(1)}
+				h.BaseFees = types.VectorFeeBigint{big.NewInt(0), big.NewInt(1), big.NewInt(1)}
 				return h
 			}(),
 			expectError:  true,

--- a/consensus/misc/eip7706/eip7706_test.go
+++ b/consensus/misc/eip7706/eip7706_test.go
@@ -104,6 +104,17 @@ func TestCalcBaseFees(t *testing.T) {
 		expectedBaseFees types.VectorFeeBigint
 		description      string
 	}{
+
+		{
+			parentExecGas:   types.VectorGasLimit{0, 0, 0},
+			parentGasLimits: types.VectorGasLimit{0, 0, 0},
+			expectedBaseFees: types.VectorFeeBigint{
+				big.NewInt(1),
+				big.NewInt(1),
+				big.NewInt(1),
+			},
+			description: "All zero",
+		},
 		{
 			parentExecGas:   types.VectorGasLimit{10_000_000, 10_000_000, 10_000_000},
 			parentGasLimits: types.VectorGasLimit{20_000_000, 20_000_000, 40_000_000},

--- a/consensus/misc/eip7706/eip7706_test.go
+++ b/consensus/misc/eip7706/eip7706_test.go
@@ -1,0 +1,148 @@
+package eip7706
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func TestGetBlockTargets(t *testing.T) {
+	tests := []struct {
+		parentGasLimits   types.VectorGasLimit
+		limitTargetRatios [3]uint64
+		want              types.VectorGasLimit
+	}{
+		// Basic case
+		{
+			parentGasLimits:   types.VectorGasLimit{10000000, 20000000, 40000000},
+			limitTargetRatios: [3]uint64{2, 2, 4},
+			want:              types.VectorGasLimit{5000000, 10000000, 10000000},
+		},
+		// Edge case: Zero gas limits
+		{
+			parentGasLimits:   types.VectorGasLimit{0, 0, 0},
+			limitTargetRatios: [3]uint64{2, 2, 4},
+			want:              types.VectorGasLimit{0, 0, 0},
+		},
+		// Edge case: Zero limit target ratios
+		{
+			parentGasLimits:   types.VectorGasLimit{10000000, 20000000, 40000000},
+			limitTargetRatios: [3]uint64{0, 0, 0}, // Should handle division by zero
+			want:              types.VectorGasLimit{0, 0, 0},
+		},
+		// Edge case: limit target ratios and parent gas limits don't have same element count
+		{
+			parentGasLimits:   types.VectorGasLimit{10000000, 20000000, 40000000},
+			limitTargetRatios: [3]uint64{1, 2},
+			want:              types.VectorGasLimit{10000000, 10000000, 0},
+		},
+	}
+
+	defaultParams := params.LimitTargetRatios
+	for i, tt := range tests {
+		params.LimitTargetRatios = tt.limitTargetRatios // Set the ratios for the test
+		got := getBlockTargets(tt.parentGasLimits)
+
+		if got != tt.want {
+			t.Errorf("test %d: getBlockTargets(%v) = %v; want %v",
+				i, tt.parentGasLimits, got, tt.want)
+		}
+	}
+
+	params.LimitTargetRatios = defaultParams
+}
+
+func TestCalcExecGas(t *testing.T) {
+	tests := []struct {
+		parentGasUsed   types.VectorGasLimit
+		parentExecGas   types.VectorGasLimit
+		parentGasLimits types.VectorGasLimit
+		want            types.VectorGasLimit
+	}{
+		// Basic case
+		{
+			parentGasUsed:   types.VectorGasLimit{10000000, 15000000, 20000000},
+			parentExecGas:   types.VectorGasLimit{5000000, 10000000, 15000000},
+			parentGasLimits: types.VectorGasLimit{20000000, 40000000, 80000000},
+			want:            types.VectorGasLimit{5000000, 5000000, 15000000},
+		},
+
+		// Basic case clamp at zero
+		{
+			parentGasUsed:   types.VectorGasLimit{10000000, 15000000, 2000},
+			parentExecGas:   types.VectorGasLimit{5000000, 10000000, 1500},
+			parentGasLimits: types.VectorGasLimit{20000000, 40000000, 80000000},
+			want:            types.VectorGasLimit{5000000, 5000000, 0},
+		},
+		// Edge case: Zero gas used and exec gas
+		{
+			parentGasUsed:   types.VectorGasLimit{0, 0, 0},
+			parentExecGas:   types.VectorGasLimit{0, 0, 0},
+			parentGasLimits: types.VectorGasLimit{20000000, 40000000, 80000000},
+			want:            types.VectorGasLimit{0, 0, 0},
+		},
+	}
+
+	for i, tt := range tests {
+		got := CalcExecGas(tt.parentGasUsed, tt.parentExecGas, tt.parentGasLimits)
+
+		if got != tt.want {
+			t.Errorf("test %d: CalcExecGas(%v, %v, %v) = %v; want %v",
+				i, tt.parentGasUsed, tt.parentExecGas, tt.parentGasLimits, got, tt.want)
+		}
+	}
+}
+
+// func TestCalcBaseFees(t *te
+func TestCalcBaseFees(t *testing.T) {
+	tests := []struct {
+		parentExecGas    types.VectorGasLimit
+		parentGasLimits  types.VectorGasLimit
+		expectedBaseFees types.VectorFeeBigint
+		description      string
+	}{
+		{
+			parentExecGas:   types.VectorGasLimit{10_000_000, 10_000_000, 10_000_000},
+			parentGasLimits: types.VectorGasLimit{20_000_000, 20_000_000, 40_000_000},
+			expectedBaseFees: types.VectorFeeBigint{
+				big.NewInt(1),
+				big.NewInt(1),
+				big.NewInt(1),
+			},
+			description: "Usage equals target",
+		},
+		{
+			parentExecGas:   types.VectorGasLimit{9_000_000, 9_000_000, 9_000_000},
+			parentGasLimits: types.VectorGasLimit{20_000_000, 20_000_000, 40_000_000},
+			expectedBaseFees: types.VectorFeeBigint{
+				big.NewInt(1),
+				big.NewInt(1),
+				big.NewInt(1),
+			},
+			description: "Usage below target",
+		},
+		{
+			parentExecGas:   types.VectorGasLimit{60_000_000, 80_000_000, 80_000_000},
+			parentGasLimits: types.VectorGasLimit{20_000_000, 20_000_000, 40_000_000},
+			expectedBaseFees: types.VectorFeeBigint{
+				big.NewInt(2),
+				big.NewInt(2),
+				big.NewInt(2),
+			},
+			description: "Usage above target",
+		},
+	}
+
+	gasType := [3]string{"execution", "blob", "calldata"}
+	for i, test := range tests {
+		have := CalcBaseFees(test.parentExecGas, test.parentGasLimits)
+		for j := 0; j < 3; j++ {
+			if have[j].Cmp(test.expectedBaseFees[j]) != 0 {
+				t.Errorf("test %d (%s), gas type %s: have %d, want %d",
+					i, test.description, gasType[j], have[j], test.expectedBaseFees[j])
+			}
+		}
+	}
+}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -183,3 +183,9 @@ func CalcGasLimit(parentGasLimit, desiredLimit uint64) uint64 {
 	}
 	return limit
 }
+
+// CalcGasLimits computes gas limits of the next block after parent  per EIP-7706
+func CalcGasLimits(parentGasLimit, desiredLimit uint64) types.VectorGasLimit {
+	executionGasLimit := CalcGasLimit(parentGasLimit, desiredLimit)
+	return types.VectorGasLimit{executionGasLimit, params.MaxBlobGasPerBlock, executionGasLimit / params.CallDataGasLimitRatio}
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2157,6 +2157,7 @@ func (bc *BlockChain) recoverAncestors(block *types.Block, makeWitness bool) (co
 	return block.Hash(), nil
 }
 
+// TODO: [rollup-geth] how do we handle VectorGasPrice
 // collectLogs collects the logs that were generated or removed during
 // the processing of a block. These logs are later announced as deleted or reborn.
 func (bc *BlockChain) collectLogs(b *types.Block, removed bool) []*types.Log {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -568,6 +568,9 @@ func (cm *chainMaker) makeHeader(parent *types.Block, state *state.StateDB, engi
 		header.BlobGasUsed = new(uint64)
 		header.ParentBeaconRoot = new(common.Hash)
 	}
+
+	//TODO: [rollup-geth] for testing purposes add generating EIP-7706 block headers
+
 	return header
 }
 

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -229,6 +229,7 @@ func (b *BlockGen) AddUncle(h *types.Header) {
 	h.Difficulty = b.engine.CalcDifficulty(b.cm, b.header.Time, parent)
 
 	// The gas limit and price should be derived from the parent
+	//TODO: [rollup-geth] add EIP-7706 base fees and gas limits calculation
 	h.GasLimit = parent.GasLimit
 	if b.cm.config.IsLondon(h.Number) {
 		h.BaseFee = eip1559.CalcBaseFee(b.cm.config, parent)
@@ -401,6 +402,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		if block.ExcessBlobGas() != nil {
 			blobGasPrice = eip4844.CalcBlobFee(*block.ExcessBlobGas())
 		}
+		//TODO: [rollup-geth] what about VectorBaseFees/VectorGasPrices
 		if err := receipts.DeriveFields(config, block.Hash(), block.NumberU64(), block.Time(), block.BaseFee(), blobGasPrice, txs); err != nil {
 			panic(err)
 		}
@@ -507,6 +509,8 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 		if block.ExcessBlobGas() != nil {
 			blobGasPrice = eip4844.CalcBlobFee(*block.ExcessBlobGas())
 		}
+
+		//TODO: [rollup-geth] what about VectorBaseFees/VectorGasPrices
 		if err := receipts.DeriveFields(config, block.Hash(), block.NumberU64(), block.Time(), block.BaseFee(), blobGasPrice, txs); err != nil {
 			panic(err)
 		}
@@ -547,6 +551,7 @@ func (cm *chainMaker) makeHeader(parent *types.Block, state *state.StateDB, engi
 		Time:       time,
 	}
 
+	//TODO: [rollup-geth] add EIP-7706 base fees and gas limits calculation
 	if cm.config.IsLondon(header.Number) {
 		header.BaseFee = eip1559.CalcBaseFee(cm.config, parent.Header())
 		if !cm.config.IsLondon(parent.Number()) {

--- a/core/evm.go
+++ b/core/evm.go
@@ -74,6 +74,7 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 		BlobBaseFee: blobBaseFee,
 		GasLimit:    header.GasLimit,
 		Random:      random,
+		BaseFees:    header.BaseFees.VectorCopy(),
 	}
 }
 

--- a/core/evm.go
+++ b/core/evm.go
@@ -62,6 +62,12 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 	if header.Difficulty.Sign() == 0 {
 		random = &header.MixDigest
 	}
+
+	baseFees := types.NewVectorFeeBigInt()
+	if header.BaseFees != nil {
+		baseFees = header.BaseFees.VectorCopy()
+	}
+
 	return vm.BlockContext{
 		CanTransfer: CanTransfer,
 		Transfer:    Transfer,
@@ -74,7 +80,7 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 		BlobBaseFee: blobBaseFee,
 		GasLimit:    header.GasLimit,
 		Random:      random,
-		BaseFees:    header.BaseFees.VectorCopy(),
+		BaseFees:    baseFees,
 	}
 }
 

--- a/core/evm.go
+++ b/core/evm.go
@@ -43,6 +43,7 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 	var (
 		beneficiary common.Address
 		baseFee     *big.Int
+		baseFees    types.VectorFeeBigint
 		blobBaseFee *big.Int
 		random      *common.Hash
 	)
@@ -63,7 +64,6 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 		random = &header.MixDigest
 	}
 
-	baseFees := types.NewVectorFeeBigInt()
 	if header.BaseFees != nil {
 		baseFees = header.BaseFees.VectorCopy()
 	}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -59,8 +59,9 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 		if interrupt != nil && interrupt.Load() {
 			return
 		}
+		//[rollup-geth] EIP-7706
 		// Convert the transaction into an executable message and pre-cache its sender
-		msg, err := TransactionToMessage(tx, signer, header.BaseFee)
+		msg, err := TransactionToMessage(tx, signer, header, p.config)
 		if err != nil {
 			return // Also invalid block, bail out
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -81,9 +81,11 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	if p.config.IsPrague(block.Number(), block.Time()) {
 		ProcessParentBlockHash(block.ParentHash(), vmenv, statedb)
 	}
+
+	//[rollup-geth] EIP-7706
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
-		msg, err := TransactionToMessage(tx, signer, header.BaseFee)
+		msg, err := TransactionToMessage(tx, signer, header, p.config)
 		if err != nil {
 			return nil, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
@@ -188,12 +190,13 @@ func MakeReceipt(evm *vm.EVM, result *ExecutionResult, statedb *state.StateDB, b
 	return receipt
 }
 
+// [rollup-geth] EIP-7706
 // ApplyTransaction attempts to apply a transaction to the given state database
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,
 // indicating the block was invalid.
 func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
-	msg, err := TransactionToMessage(tx, types.MakeSigner(config, header.Number, header.Time), header.BaseFee)
+	msg, err := TransactionToMessage(tx, types.MakeSigner(config, header.Number, header.Time), header, config)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -382,6 +382,8 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 		Time:       parent.Time() + 10,
 		UncleHash:  types.EmptyUncleHash,
 	}
+
+	//TODO: [rollup-geth] if calc EIP-7706 base fees
 	if config.IsLondon(header.Number) {
 		header.BaseFee = eip1559.CalcBaseFee(config, parent.Header())
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -149,8 +149,7 @@ type Message struct {
 	// When SkipFromEOACheck is true, the message sender is not checked to be an EOA.
 	SkipFromEOACheck bool
 
-	//[rollup-geth]
-	EffectiveGasTip    *big.Int
+	//[rollup-geth] EIP-7706
 	EffectiveGasPrices types.VectorFeeBigint
 	EffectiveGasTips   types.VectorFeeBigint
 
@@ -159,10 +158,8 @@ type Message struct {
 	GasTipCaps types.VectorFeeBigint
 }
 
-// TODO: go through all the references of this function call and see where we have to update to our newly added  TransactionToMessageEIP7706
-
 // TransactionToMessage converts a transaction into a Message.
-func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.Int) (*Message, error) {
+func TransactionToMessageEIP4844(tx *types.Transaction, s types.Signer, baseFee *big.Int) (*Message, error) {
 	msg := &Message{
 		Nonce:            tx.Nonce(),
 		GasLimit:         tx.Gas(),
@@ -177,12 +174,11 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.In
 		BlobHashes:       tx.BlobHashes(),
 		BlobGasFeeCap:    tx.BlobGasFeeCap(),
 
-		//[rollup-geth]
-		GasFeeCaps:      tx.GasFeeCaps(),
-		GasTipCaps:      tx.GasTipCaps(),
-		GasLimits:       tx.GasLimits(),
-		EffectiveGasTip: tx.EffectiveGasTipValue(baseFee),
-		GasPrice:        tx.EffectiveGasPrice(baseFee), //[rollup-geth]
+		//[rollup-geth] EIP-7706 added fields
+		GasFeeCaps: tx.GasFeeCaps(),
+		GasTipCaps: tx.GasTipCaps(),
+		GasLimits:  tx.GasLimits(),
+		GasPrice:   tx.EffectiveGasPrice(baseFee),
 	}
 
 	var err error

--- a/core/state_transition_rollup.go
+++ b/core/state_transition_rollup.go
@@ -17,7 +17,7 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, h *types.Header
 		if h.BaseFees == nil {
 			return nil, fmt.Errorf("base fees not set")
 		}
-		return TransactionToMessageEIP7706(tx, s, *h.BaseFees)
+		return TransactionToMessageEIP7706(tx, s, h.BaseFees)
 	}
 
 	return TransactionToMessageEIP4844(tx, s, h.GetBaseFee())

--- a/core/state_transition_rollup.go
+++ b/core/state_transition_rollup.go
@@ -14,7 +14,10 @@ import (
 
 func TransactionToMessage(tx *types.Transaction, s types.Signer, h *types.Header, chainConfig *params.ChainConfig) (*Message, error) {
 	if chainConfig.IsEIP7706(h.Number, h.Time) {
-		return TransactionToMessageEIP7706(tx, s, h.BaseFees)
+		if h.BaseFees == nil {
+			return nil, fmt.Errorf("base fees not set")
+		}
+		return TransactionToMessageEIP7706(tx, s, *h.BaseFees)
 	}
 
 	return TransactionToMessageEIP4844(tx, s, h.GetBaseFee())

--- a/core/state_transition_rollup.go
+++ b/core/state_transition_rollup.go
@@ -304,7 +304,7 @@ func (st *StateTransition) vectorGasUsed() types.VectorGasLimit {
 	// Blob and calldata gas used is actually same as their gas limits (because it is precomputed from tx data and known upfront)
 	// Only execution gas is not known upfront and has to be determined while executing the transaction
 	gasUsed := st.msg.GasLimits
-	gasUsed[0] = st.gasUsed()
+	gasUsed[types.ExecutionGasIndex] = st.gasUsed()
 
 	return gasUsed
 }

--- a/core/state_transition_rollup.go
+++ b/core/state_transition_rollup.go
@@ -372,5 +372,5 @@ func (st *StateTransition) vectorGasRemaining() types.VectorGasLimit {
 
 	//NOTE: 2 msg.GasLimits[0] == msg.GasLimit == st.initialGas
 	// this is why this holds
-	return st.msg.GasLimits.VectorSubtract(st.vectorGasUsed())
+	return st.msg.GasLimits.VectorSubtractClampAtZero(st.vectorGasUsed())
 }

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -402,7 +402,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserve txpool.Addres
 	}
 	var (
 		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), p.head))
-		blobfee = uint256.NewInt(params.BlobTxMinBlobGasprice)
+		blobfee = uint256.NewInt(params.TxMinGasPrice)
 	)
 	if p.head.ExcessBlobGas != nil {
 		blobfee = uint256.MustFromBig(eip4844.CalcBlobFee(*p.head.ExcessBlobGas))
@@ -823,7 +823,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	// Reset the price heap for the new set of basefee/blobfee pairs
 	var (
 		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), newHead))
-		blobfee = uint256.MustFromBig(big.NewInt(params.BlobTxMinBlobGasprice))
+		blobfee = uint256.MustFromBig(big.NewInt(params.TxMinGasPrice))
 	)
 	if newHead.ExcessBlobGas != nil {
 		blobfee = uint256.MustFromBig(eip4844.CalcBlobFee(*newHead.ExcessBlobGas))

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -400,6 +400,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserve txpool.Addres
 	for addr := range p.index {
 		p.recheck(addr, nil)
 	}
+	//TODO:[rollup-geth] what about EIP-7706 base fees?
 	var (
 		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), p.head))
 		blobfee = uint256.NewInt(params.TxMinGasPrice)
@@ -821,6 +822,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 		p.limbo.finalize(p.chain.CurrentFinalBlock())
 	}
 	// Reset the price heap for the new set of basefee/blobfee pairs
+	//TODO:[rollup-geth] what about EIP-7706 base fees?
 	var (
 		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), newHead))
 		blobfee = uint256.MustFromBig(big.NewInt(params.TxMinGasPrice))

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -561,7 +561,7 @@ func TestOpenDrops(t *testing.T) {
 	chain := &testBlockChain{
 		config:  params.MainnetChainConfig,
 		basefee: uint256.NewInt(params.InitialBaseFee),
-		blobfee: uint256.NewInt(params.BlobTxMinBlobGasprice),
+		blobfee: uint256.NewInt(params.TxMinGasPrice),
 		statedb: statedb,
 	}
 	pool := New(Config{Datadir: storage}, chain)
@@ -680,7 +680,7 @@ func TestOpenIndex(t *testing.T) {
 	chain := &testBlockChain{
 		config:  params.MainnetChainConfig,
 		basefee: uint256.NewInt(params.InitialBaseFee),
-		blobfee: uint256.NewInt(params.BlobTxMinBlobGasprice),
+		blobfee: uint256.NewInt(params.TxMinGasPrice),
 		statedb: statedb,
 	}
 	pool := New(Config{Datadir: storage}, chain)
@@ -1244,7 +1244,7 @@ func TestAdd(t *testing.T) {
 				},
 				{ // Same as above but blob fee cap equals minimum, should be accepted
 					from: "alice",
-					tx:   makeUnsignedTx(0, 1, 1, params.BlobTxMinBlobGasprice),
+					tx:   makeUnsignedTx(0, 1, 1, params.TxMinGasPrice),
 					err:  nil,
 				},
 			},

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1298,6 +1298,7 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 	if reset != nil {
 		pool.demoteUnexecutables()
 		if reset.newHead != nil {
+			//TODO:[rollup-geth] what about EIP-7706 base fees?
 			if pool.chainconfig.IsLondon(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
 				pendingBaseFee := eip1559.CalcBaseFee(pool.chainconfig, reset.newHead)
 				pool.priced.SetBaseFee(pendingBaseFee)

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -34,7 +34,7 @@ import (
 var (
 	// blobTxMinBlobGasPrice is the big.Int version of the configured protocol
 	// parameter to avoid constructing a new big integer for every transaction.
-	blobTxMinBlobGasPrice = big.NewInt(params.BlobTxMinBlobGasprice)
+	blobTxMinBlobGasPrice = big.NewInt(params.TxMinGasPrice)
 )
 
 // ValidationOptions define certain differences between transaction validation

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -107,14 +107,14 @@ type Header struct {
 	RequestsHash *common.Hash `json:"requestsRoot" rlp:"optional"`
 
 	//[rollup-geth] EIP-7706 required fields
-	GasLimits     *VectorGasLimit `json:"gasLimits" rlp:"optional"`
-	GasUsedVector *VectorGasLimit `json:"gasUsedVector" rlp:"optional"`
-	ExcessGas     *VectorGasLimit `json:"excessGas" rlp:"optional"`
+	GasLimits     VectorGasLimit `json:"gasLimits" rlp:"optional"`
+	GasUsedVector VectorGasLimit `json:"gasUsedVector" rlp:"optional"`
+	ExcessGas     VectorGasLimit `json:"excessGas" rlp:"optional"`
 
 	//NOTE: [rollup-geth] per EIP-7706 this field is not actually part of block header
 	//Not having this field as part of header would require even bigger code refactor
 	//thus, for time being I'm leaving this here and I want to double check if BaseFees where omitted deliberately
-	BaseFees *VectorFeeBigint `rlp:"-" json:"-"`
+	BaseFees VectorFeeBigint `rlp:"-" json:"-"`
 }
 
 // field type overrides for gencodec
@@ -361,8 +361,7 @@ func CopyHeader(h *Header) *Header {
 
 	//[rollup-geth] EIP-7706
 	if h.BaseFees != nil {
-		cpy.BaseFees = new(VectorFeeBigint)
-		*cpy.BaseFees = (*h.BaseFees).VectorCopy()
+		cpy.BaseFees = h.BaseFees.VectorCopy()
 	}
 
 	cpy.GasLimits = h.GasLimits

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -107,14 +107,14 @@ type Header struct {
 	RequestsHash *common.Hash `json:"requestsRoot" rlp:"optional"`
 
 	//[rollup-geth] EIP-7706 required fields
-	GasLimits     VectorGasLimit `json:"gasLimits" rlp:"optional"`
-	GasUsedVector VectorGasLimit `json:"gasUsedVector" rlp:"optional"`
-	ExcessGas     VectorGasLimit `json:"excessGas" rlp:"optional"`
+	GasLimits     *VectorGasLimit `json:"gasLimits" rlp:"optional"`
+	GasUsedVector *VectorGasLimit `json:"gasUsedVector" rlp:"optional"`
+	ExcessGas     *VectorGasLimit `json:"excessGas" rlp:"optional"`
 
 	//NOTE: [rollup-geth] per EIP-7706 this field is not actually part of block header
 	//Not having this field as part of header would require even bigger code refactor
 	//thus, for time being I'm leaving this here and I want to double check if BaseFees where omitted deliberately
-	BaseFees VectorFeeBigint `rlp:"optional"`
+	BaseFees *VectorFeeBigint `rlp:"optional"`
 }
 
 // field type overrides for gencodec
@@ -360,7 +360,11 @@ func CopyHeader(h *Header) *Header {
 	}
 
 	//[rollup-geth] EIP-7706
-	cpy.BaseFees = h.BaseFees.VectorCopy()
+	if h.BaseFees != nil {
+		cpy.BaseFees = new(VectorFeeBigint)
+		*cpy.BaseFees = (*h.BaseFees).VectorCopy()
+	}
+
 	cpy.GasLimits = h.GasLimits
 	cpy.ExcessGas = h.ExcessGas
 	cpy.GasUsedVector = h.GasUsedVector

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -114,7 +114,7 @@ type Header struct {
 	//NOTE: [rollup-geth] per EIP-7706 this field is not actually part of block header
 	//Not having this field as part of header would require even bigger code refactor
 	//thus, for time being I'm leaving this here and I want to double check if BaseFees where omitted deliberately
-	BaseFees *VectorFeeBigint `rlp:"optional"`
+	BaseFees *VectorFeeBigint `rlp:"-" json:"-"`
 }
 
 // field type overrides for gencodec

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -105,6 +105,10 @@ type Header struct {
 
 	// RequestsHash was added by EIP-7685 and is ignored in legacy headers.
 	RequestsHash *common.Hash `json:"requestsRoot" rlp:"optional"`
+
+	//[rollup-geth]
+	//Fields required by EIP-7706
+	BaseFees VectorFeeBigint `json:"baseFees" rlp:"optional"`
 }
 
 // field type overrides for gencodec
@@ -160,6 +164,8 @@ func (h *Header) SanityCheck() error {
 			return fmt.Errorf("too large base fee: bitlen %d", bfLen)
 		}
 	}
+
+	//TODO: [rollup-geth] validate vector of base fees
 	return nil
 }
 
@@ -176,6 +182,14 @@ func (h *Header) EmptyBody() bool {
 // EmptyReceipts returns true if there are no receipts for this header/block.
 func (h *Header) EmptyReceipts() bool {
 	return h.ReceiptHash == EmptyReceiptsHash
+}
+
+// TODO: [rollup-geth] Do we need BaseFees() as well?
+func (h *Header) GetBaseFee() *big.Int {
+	if h.BaseFee == nil {
+		return nil
+	}
+	return new(big.Int).Set(h.BaseFee)
 }
 
 // Body is a simple (mutable, non-safe) data container for storing and moving
@@ -338,6 +352,9 @@ func CopyHeader(h *Header) *Header {
 		cpy.RequestsHash = new(common.Hash)
 		*cpy.RequestsHash = *h.RequestsHash
 	}
+
+	//[rollup-geth] EIP-7706
+	cpy.BaseFees = h.BaseFees.VectorCopy()
 	return &cpy
 }
 
@@ -412,6 +429,7 @@ func (b *Block) ReceiptHash() common.Hash { return b.header.ReceiptHash }
 func (b *Block) UncleHash() common.Hash   { return b.header.UncleHash }
 func (b *Block) Extra() []byte            { return common.CopyBytes(b.header.Extra) }
 
+// TODO: [rollup-geth] Do we need BaseFees() as well?
 func (b *Block) BaseFee() *big.Int {
 	if b.header.BaseFee == nil {
 		return nil

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -106,12 +106,19 @@ type Header struct {
 	// RequestsHash was added by EIP-7685 and is ignored in legacy headers.
 	RequestsHash *common.Hash `json:"requestsRoot" rlp:"optional"`
 
-	//[rollup-geth]
-	//Fields required by EIP-7706
-	BaseFees VectorFeeBigint `json:"baseFees" rlp:"optional"`
+	//[rollup-geth] EIP-7706 required fields
+	GasLimits     VectorGasLimit `json:"gasLimits" rlp:"optional"`
+	GasUsedVector VectorGasLimit `json:"gasUsedVector" rlp:"optional"`
+	ExcessGas     VectorGasLimit `json:"excessGas" rlp:"optional"`
+
+	//NOTE: [rollup-geth] per EIP-7706 this field is not actually part of block header
+	//Not having this field as part of header would require even bigger code refactor
+	//thus, for time being I'm leaving this here and I want to double check if BaseFees where omitted deliberately
+	BaseFees VectorFeeBigint `rlp:"optional"`
 }
 
 // field type overrides for gencodec
+// TODO: [rollup-geth] add EIP-7706 fields here
 type headerMarshaling struct {
 	Difficulty    *hexutil.Big
 	Number        *hexutil.Big
@@ -165,7 +172,6 @@ func (h *Header) SanityCheck() error {
 		}
 	}
 
-	//TODO: [rollup-geth] validate vector of base fees
 	return nil
 }
 
@@ -355,6 +361,10 @@ func CopyHeader(h *Header) *Header {
 
 	//[rollup-geth] EIP-7706
 	cpy.BaseFees = h.BaseFees.VectorCopy()
+	cpy.GasLimits = h.GasLimits
+	cpy.ExcessGas = h.ExcessGas
+	cpy.GasUsedVector = h.GasUsedVector
+
 	return &cpy
 }
 

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -55,6 +55,8 @@ type txJSON struct {
 
 	// Only used for encoding:
 	Hash common.Hash `json:"hash"`
+
+	//TODO: add marshaling vector_fee_tx fields
 }
 
 // yParityValue returns the YParity value from JSON. For backwards-compatibility reasons,

--- a/core/types/transaction_rollup.go
+++ b/core/types/transaction_rollup.go
@@ -19,7 +19,7 @@ func (tx *Transaction) GasFeeCaps() VectorFeeBigint { return tx.inner.gasFeeCaps
 func (tx *Transaction) EffectiveGasTips(baseFees VectorFeeBigint) VectorFeeBigint {
 	gasFeeCaps := tx.GasFeeCaps()
 	gasTipCaps := tx.GasTipCaps()
-	effectiveTips := NewVectorFeeBigInt()
+	effectiveTips := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, baseFee := range baseFees {
 		if baseFee == nil {
 			effectiveTips[i].Set(gasTipCaps[i])
@@ -35,7 +35,7 @@ func (tx *Transaction) EffectiveGasTips(baseFees VectorFeeBigint) VectorFeeBigin
 func (tx *Transaction) EffectiveGasPrices(baseFees VectorFeeBigint) VectorFeeBigint {
 	gasFeeCaps := tx.GasFeeCaps()
 	gasTipCaps := tx.GasTipCaps()
-	effectiveFees := NewVectorFeeBigInt()
+	effectiveFees := make(VectorFeeBigint, VectorFeeTypesCount)
 
 	for i, baseFee := range baseFees {
 		if baseFee == nil {
@@ -54,5 +54,5 @@ func (tx *Transaction) EffectiveGasPrice(baseFee *big.Int) *big.Int {
 }
 
 func (tx *Transaction) EffectiveGasExecutionPrice(baseFees VectorFeeBigint) *big.Int {
-	return tx.EffectiveGasPrices(baseFees)[0]
+	return tx.EffectiveGasPrices(baseFees)[ExecutionGasIndex]
 }

--- a/core/types/transaction_rollup.go
+++ b/core/types/transaction_rollup.go
@@ -52,3 +52,7 @@ func (tx *Transaction) EffectiveGasPrices(baseFees VectorFeeBigint) VectorFeeBig
 func (tx *Transaction) EffectiveGasPrice(baseFee *big.Int) *big.Int {
 	return tx.inner.effectiveGasPrice(new(big.Int), baseFee)
 }
+
+func (tx *Transaction) EffectiveGasExecutionPrice(baseFees VectorFeeBigint) *big.Int {
+	return tx.EffectiveGasPrices(baseFees)[0]
+}

--- a/core/types/tx_vector_fee.go
+++ b/core/types/tx_vector_fee.go
@@ -46,7 +46,7 @@ func (tx *VectorFeeTx) gasLimits() VectorGasLimit {
 }
 
 func (tx *VectorFeeTx) gasTipCaps() VectorFeeBigint {
-	var feesAsBigInt VectorFeeBigint
+	feesAsBigInt := make(VectorFeeBigint, len(tx.GasTipCaps))
 	for i, f := range tx.GasTipCaps {
 		feesAsBigInt[i] = f.ToBig()
 	}
@@ -55,7 +55,7 @@ func (tx *VectorFeeTx) gasTipCaps() VectorFeeBigint {
 }
 
 func (tx *VectorFeeTx) gasFeeCaps() VectorFeeBigint {
-	var feesAsBigInt VectorFeeBigint
+	feesAsBigInt := make(VectorFeeBigint, len(tx.GasFeeCaps))
 	for i, f := range tx.GasFeeCaps {
 		feesAsBigInt[i] = f.ToBig()
 	}

--- a/core/types/tx_vector_fee.go
+++ b/core/types/tx_vector_fee.go
@@ -46,7 +46,7 @@ func (tx *VectorFeeTx) gasLimits() VectorGasLimit {
 }
 
 func (tx *VectorFeeTx) gasTipCaps() VectorFeeBigint {
-	feesAsBigInt := make(VectorFeeBigint, len(tx.GasTipCaps))
+	feesAsBigInt := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, f := range tx.GasTipCaps {
 		feesAsBigInt[i] = f.ToBig()
 	}
@@ -55,7 +55,7 @@ func (tx *VectorFeeTx) gasTipCaps() VectorFeeBigint {
 }
 
 func (tx *VectorFeeTx) gasFeeCaps() VectorFeeBigint {
-	feesAsBigInt := make(VectorFeeBigint, len(tx.GasFeeCaps))
+	feesAsBigInt := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, f := range tx.GasFeeCaps {
 		feesAsBigInt[i] = f.ToBig()
 	}
@@ -112,12 +112,12 @@ func (tx *VectorFeeTx) copy() TxData {
 		Data:  common.CopyBytes(tx.Data),
 		Gas:   tx.Gas,
 		// These are copied below.
+		GasTipCaps: make(VectorFeeUint, len(tx.GasTipCaps)),
+		GasFeeCaps: make(VectorFeeUint, len(tx.GasFeeCaps)),
 		AccessList: make(AccessList, len(tx.AccessList)),
 		BlobHashes: make([]common.Hash, len(tx.BlobHashes)),
 		Value:      new(uint256.Int),
 		ChainID:    new(uint256.Int),
-		GasTipCaps: VectorFeeUint{},
-		GasFeeCaps: VectorFeeUint{},
 		V:          new(uint256.Int),
 		R:          new(uint256.Int),
 		S:          new(uint256.Int),

--- a/core/types/vector_fee.go
+++ b/core/types/vector_fee.go
@@ -32,15 +32,6 @@ const (
 // ElementNilError is returned when a vector contains nil element(s)
 var ElementNilError = errors.New("Vector contains nil element(s)")
 
-// NewVectorFeeBigInt creates a new VectorFeeBigint with all elements initialized to 0
-func NewVectorFeeBigInt() VectorFeeBigint {
-	result := make(VectorFeeBigint, VectorFeeTypesCount)
-	for i := range result {
-		result[i] = new(big.Int)
-	}
-	return result
-}
-
 // VectorCopy creates a deep copy of the VectorFeeBigint, nils are copied as nils
 func (vec VectorFeeBigint) VectorCopy() VectorFeeBigint {
 	result := make(VectorFeeBigint, VectorFeeTypesCount)

--- a/core/types/vector_fee.go
+++ b/core/types/vector_fee.go
@@ -1,8 +1,12 @@
+// Package types provides vector operations for new EIP-7706 TX type which introduces multi-dimensional fee structure
 package types
 
 import (
-	"github.com/holiman/uint256"
+	"errors"
 	"math/big"
+	"slices"
+
+	"github.com/holiman/uint256"
 )
 
 type (
@@ -12,26 +16,38 @@ type (
 )
 
 const (
+	// ExecutionGasIndex represents the index for execution gas in fee vectors
 	ExecutionGasIndex = iota
+
+	// BlobGasIndex represents the index for blob gas in fee vectors
 	BlobGasIndex
+
+	// CalldataGasIndex represents the index for calldata gas in fee vectors
 	CalldataGasIndex
+
+	// VectorFeeTypesCount defines the total number of fee types supported
+	VectorFeeTypesCount = 3
 )
 
-const VectorFeeTypesCount = 3
+// ElementNilError is returned when a vector contains nil element(s)
+var ElementNilError = errors.New("Vector contains nil element(s)")
 
+// NewVectorFeeBigInt creates a new VectorFeeBigint with all elements initialized to 0
 func NewVectorFeeBigInt() VectorFeeBigint {
 	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i := range result {
 		result[i] = new(big.Int)
 	}
-
 	return result
 }
 
+// VectorCopy creates a deep copy of the VectorFeeBigint, nils are copied as nils
 func (vec VectorFeeBigint) VectorCopy() VectorFeeBigint {
 	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, v := range vec {
-		if v != nil {
+		if v == nil {
+			result[i] = nil
+		} else {
 			result[i] = new(big.Int).Set(v)
 		}
 	}
@@ -39,45 +55,46 @@ func (vec VectorFeeBigint) VectorCopy() VectorFeeBigint {
 	return result
 }
 
-func (vec VectorFeeBigint) Sum() *big.Int {
+// Sum calculates the sum of all elements in the vector
+// Returns error if vector contains nil element(s)
+func (vec VectorFeeBigint) Sum() (*big.Int, error) {
+	if vec.ContainsNilElement() {
+		return nil, ElementNilError
+	}
+
 	sum := big.NewInt(0)
 	for _, v := range vec {
-		if v != nil {
-			sum = sum.Add(sum, v)
-		}
+		sum = sum.Add(sum, v)
 	}
 
-	return sum
+	return sum, nil
 }
 
-func (vec VectorFeeBigint) VectorAllEq(other VectorFeeBigint) bool {
-	for i, v := range vec {
-		if bothValuesNil := v == nil && other[i] == nil; bothValuesNil {
-			continue
+// VectorAllEq compares two VectorFeeBigint for equality.
+// Returns true if all corresponding elements are either both nil or equal in value.
+func (vec VectorFeeBigint) VectorAllEq(vecOther VectorFeeBigint) bool {
+	return slices.EqualFunc(vec, vecOther, func(val, other *big.Int) bool {
+		if bothValuesNil := val == nil && other == nil; bothValuesNil {
+			return true
 		}
 
-		if onlyOneOfTheValuesNil := v == nil || other[i] == nil; onlyOneOfTheValuesNil {
+		if onlyOneOfTheValuesNil := val == nil || other == nil; onlyOneOfTheValuesNil {
 			return false
 		}
 
-		if v.Cmp(other[i]) != 0 {
-			return false
-		}
-	}
-
-	return true
+		return val.Cmp(other) == 0
+	})
 }
 
+// VectorAllLessOrEqual checks if all elements in vec are less than or equal to
+// corresponding elements in other vector.
+// If any of the provider values contains nil element(s) returns false
 func (vec VectorFeeBigint) VectorAllLessOrEqual(other VectorFeeBigint) bool {
+	if vec.ContainsNilElement() || other.ContainsNilElement() {
+		return false
+	}
+
 	for i, v := range vec {
-		if bothValuesNil := v == nil && other[i] == nil; bothValuesNil {
-			continue
-		}
-
-		if onlyOneOfTheValuesNil := v == nil || other[i] == nil; onlyOneOfTheValuesNil {
-			return false
-		}
-
 		if v.Cmp(other[i]) > 0 {
 			return false
 		}
@@ -86,73 +103,61 @@ func (vec VectorFeeBigint) VectorAllLessOrEqual(other VectorFeeBigint) bool {
 	return true
 }
 
-func (vec VectorFeeBigint) VectorAdd(other VectorFeeBigint) VectorFeeBigint {
+// VectorAdd adds corresponding elements of two vectors.
+// Returns error if any of the provided vectors contains nil element(s)
+func (vec VectorFeeBigint) VectorAdd(other VectorFeeBigint) (VectorFeeBigint, error) {
+	if vec.ContainsNilElement() || other.ContainsNilElement() {
+		return nil, ElementNilError
+	}
+
 	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, v := range vec {
-		if bothValuesNil := v == nil && other[i] == nil; bothValuesNil {
-			continue
-		}
-
-		if v == nil {
-			result[i] = new(big.Int).Set(other[i])
-			continue
-		}
-
-		if other[i] == nil {
-			result[i] = new(big.Int).Set(v)
-			continue
-		}
-
 		result[i] = new(big.Int).Add(v, other[i])
 	}
 
-	return result
+	return result, nil
 }
 
-func (vec VectorFeeBigint) VectorMul(other VectorFeeBigint) VectorFeeBigint {
+// VectorMul multiplies corresponding elements of two vectors.
+// Returns error if any of the provided vectors contains nil element(s)
+func (vec VectorFeeBigint) VectorMul(other VectorFeeBigint) (VectorFeeBigint, error) {
+	if vec.ContainsNilElement() || other.ContainsNilElement() {
+		return nil, ElementNilError
+	}
+
 	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, v := range vec {
-		if anyValueNil := v == nil || other[i] == nil; anyValueNil {
-			continue
-		}
-
 		result[i] = new(big.Int).Mul(v, other[i])
 	}
 
-	return result
+	return result, nil
 }
 
-func (vec VectorFeeBigint) VectorSubtract(other VectorFeeBigint) VectorFeeBigint {
+// VectorSubtract subtracts corresponding elements of other from vec.
+// Returns error if any of the provided vectors contains nil element(s)
+func (vec VectorFeeBigint) VectorSubtract(other VectorFeeBigint) (VectorFeeBigint, error) {
+	if vec.ContainsNilElement() || other.ContainsNilElement() {
+		return nil, ElementNilError
+	}
+
 	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, v := range vec {
-		if bothValuesNil := v == nil && other[i] == nil; bothValuesNil {
-			continue
-		}
-
-		if v == nil {
-			result[i] = new(big.Int).Sub(big.NewInt(0), other[i])
-			continue
-		}
-
-		if other[i] == nil {
-			result[i] = new(big.Int).Set(v)
-			continue
-		}
-
 		result[i] = new(big.Int).Sub(v, other[i])
 	}
 
-	return result
+	return result, nil
 }
 
-func (vec VectorFeeBigint) VectorSubtractClampAtZero(other VectorFeeBigint) VectorFeeBigint {
+// VectorSubtractClampAtZero subtracts corresponding elements of other from vec,
+// clamping results at zero if they would be negative.
+// Returns error if any of the provided vectors contains nil element(s)
+func (vec VectorFeeBigint) VectorSubtractClampAtZero(other VectorFeeBigint) (VectorFeeBigint, error) {
+	if vec.ContainsNilElement() || other.ContainsNilElement() {
+		return nil, ElementNilError
+	}
+
 	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, v := range vec {
-		if anyValueNil := v == nil || other[i] == nil; anyValueNil {
-			result[i] = big.NewInt(0)
-			continue
-		}
-
 		if subWontProducePositiveValue := v.Cmp(other[i]) <= 0; subWontProducePositiveValue {
 			result[i] = big.NewInt(0)
 		} else {
@@ -160,84 +165,94 @@ func (vec VectorFeeBigint) VectorSubtractClampAtZero(other VectorFeeBigint) Vect
 		}
 	}
 
-	return result
+	return result, nil
 }
 
+// VecNoNilElements checks if vector contains nil element
+func (vec VectorFeeBigint) ContainsNilElement() bool {
+	return slices.Contains(vec, nil)
+}
+
+// VectorAllNil checks if all elements in the vector are nil.
 func (vec VectorFeeBigint) VectorAllNil() bool {
 	for _, v := range vec {
 		if v != nil {
 			return false
 		}
 	}
-
 	return true
 }
 
+// VecBitLenAllZero checks if all non-nil elements have a bit length of zero.
+// Nil is treated as having a bit length of zero.
 func (vec VectorFeeBigint) VecBitLenAllZero() bool {
 	for _, v := range vec {
 		if v == nil {
 			continue
 		}
-
 		if v.BitLen() > 0 {
 			return false
 		}
 	}
-
 	return true
 }
 
+// VecBitLenAllLessEqThan256 checks if all non-nil elements have a bit length <= 256.
+// Nil is treated as having a bit length of zero.
 func (vec VectorFeeBigint) VecBitLenAllLessEqThan256() bool {
 	for _, v := range vec {
 		if v == nil {
 			continue
 		}
-
 		if v.BitLen() > 256 {
 			return false
 		}
 	}
-
 	return true
 }
 
+// ToVectorBigInt converts a VectorGasLimit to VectorFeeBigint.
 func (vec VectorGasLimit) ToVectorBigInt() VectorFeeBigint {
 	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, v := range vec {
 		result[i] = new(big.Int).SetUint64(v)
 	}
-
 	return result
 }
 
+// VectorAllEq compares two VectorGasLimit for equality.
+// Returns true if all corresponding elements are equal.
 func (vec VectorGasLimit) VectorAllEq(other VectorGasLimit) bool {
 	for i, v := range vec {
 		if v != other[i] {
 			return false
 		}
 	}
-
 	return true
 }
 
+// VectorAdd adds corresponding elements of two VectorGasLimit.
+// Note: Does not check for overflow.
 func (vec VectorGasLimit) VectorAdd(other VectorGasLimit) VectorGasLimit {
 	result := make(VectorGasLimit, VectorFeeTypesCount)
 	for i, v := range vec {
 		result[i] = v + other[i]
 	}
-
 	return result
 }
 
+// VectorSubtract subtracts corresponding elements of other from vec.
+// Note: Does not check for underflow.
 func (vec VectorGasLimit) VectorSubtract(other VectorGasLimit) VectorGasLimit {
 	result := make(VectorGasLimit, VectorFeeTypesCount)
 	for i, v := range vec {
 		result[i] = v - other[i]
 	}
-
 	return result
 }
 
+// VectorSubtractClampAtZero subtracts corresponding elements of other from vec,
+// clamping results at zero if they would be negative.
 func (vec VectorGasLimit) VectorSubtractClampAtZero(other VectorGasLimit) VectorGasLimit {
 	result := make(VectorGasLimit, VectorFeeTypesCount)
 	for i, v := range vec {
@@ -247,6 +262,5 @@ func (vec VectorGasLimit) VectorSubtractClampAtZero(other VectorGasLimit) Vector
 			result[i] = v - other[i]
 		}
 	}
-
 	return result
 }

--- a/core/types/vector_fee.go
+++ b/core/types/vector_fee.go
@@ -1,12 +1,8 @@
 package types
 
 import (
-	"fmt"
-	"io"
-	"math/big"
-
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
+	"math/big"
 )
 
 type (
@@ -138,6 +134,16 @@ func (vec VectorFeeBigint) VectorSubtractClampAtZero(other VectorFeeBigint) Vect
 	}
 
 	return result
+}
+
+func (vec VectorFeeBigint) VectorAllNil() bool {
+	for _, v := range vec {
+		if v != nil {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (vec VectorFeeBigint) VecBitLenAllZero() bool {

--- a/core/types/vector_fee.go
+++ b/core/types/vector_fee.go
@@ -6,9 +6,9 @@ import (
 )
 
 type (
-	VectorFeeUint   [3]*uint256.Int
-	VectorFeeBigint [3]*big.Int
-	VectorGasLimit  [3]uint64
+	VectorFeeUint   []*uint256.Int
+	VectorFeeBigint []*big.Int
+	VectorGasLimit  []uint64
 )
 
 const (
@@ -17,8 +17,10 @@ const (
 	CalldataGasIndex
 )
 
+const VectorFeeTypesCount = 3
+
 func NewVectorFeeBigInt() VectorFeeBigint {
-	var result VectorFeeBigint
+	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i := range result {
 		result[i] = new(big.Int)
 	}
@@ -27,8 +29,8 @@ func NewVectorFeeBigInt() VectorFeeBigint {
 }
 
 func (vec VectorFeeBigint) VectorCopy() VectorFeeBigint {
-	var result VectorFeeBigint
-	for i, v := range result {
+	result := make(VectorFeeBigint, VectorFeeTypesCount)
+	for i, v := range vec {
 		if v != nil {
 			result[i] = new(big.Int).Set(v)
 		}
@@ -85,7 +87,7 @@ func (vec VectorFeeBigint) VectorAllLessOrEqual(other VectorFeeBigint) bool {
 }
 
 func (vec VectorFeeBigint) VectorAdd(other VectorFeeBigint) VectorFeeBigint {
-	var result VectorFeeBigint
+	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, v := range vec {
 		if bothValuesNil := v == nil && other[i] == nil; bothValuesNil {
 			continue
@@ -108,7 +110,7 @@ func (vec VectorFeeBigint) VectorAdd(other VectorFeeBigint) VectorFeeBigint {
 }
 
 func (vec VectorFeeBigint) VectorMul(other VectorFeeBigint) VectorFeeBigint {
-	var result VectorFeeBigint
+	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, v := range vec {
 		if anyValueNil := v == nil || other[i] == nil; anyValueNil {
 			continue
@@ -121,7 +123,7 @@ func (vec VectorFeeBigint) VectorMul(other VectorFeeBigint) VectorFeeBigint {
 }
 
 func (vec VectorFeeBigint) VectorSubtract(other VectorFeeBigint) VectorFeeBigint {
-	var result VectorFeeBigint
+	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, v := range vec {
 		if bothValuesNil := v == nil && other[i] == nil; bothValuesNil {
 			continue
@@ -134,6 +136,7 @@ func (vec VectorFeeBigint) VectorSubtract(other VectorFeeBigint) VectorFeeBigint
 
 		if other[i] == nil {
 			result[i] = new(big.Int).Set(v)
+			continue
 		}
 
 		result[i] = new(big.Int).Sub(v, other[i])
@@ -143,7 +146,7 @@ func (vec VectorFeeBigint) VectorSubtract(other VectorFeeBigint) VectorFeeBigint
 }
 
 func (vec VectorFeeBigint) VectorSubtractClampAtZero(other VectorFeeBigint) VectorFeeBigint {
-	var result VectorFeeBigint
+	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, v := range vec {
 		if anyValueNil := v == nil || other[i] == nil; anyValueNil {
 			result[i] = big.NewInt(0)
@@ -199,7 +202,7 @@ func (vec VectorFeeBigint) VecBitLenAllLessEqThan256() bool {
 }
 
 func (vec VectorGasLimit) ToVectorBigInt() VectorFeeBigint {
-	var result VectorFeeBigint
+	result := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, v := range vec {
 		result[i] = new(big.Int).SetUint64(v)
 	}
@@ -218,7 +221,7 @@ func (vec VectorGasLimit) VectorAllEq(other VectorGasLimit) bool {
 }
 
 func (vec VectorGasLimit) VectorAdd(other VectorGasLimit) VectorGasLimit {
-	var result VectorGasLimit
+	result := make(VectorGasLimit, VectorFeeTypesCount)
 	for i, v := range vec {
 		result[i] = v + other[i]
 	}
@@ -227,7 +230,7 @@ func (vec VectorGasLimit) VectorAdd(other VectorGasLimit) VectorGasLimit {
 }
 
 func (vec VectorGasLimit) VectorSubtract(other VectorGasLimit) VectorGasLimit {
-	var result VectorGasLimit
+	result := make(VectorGasLimit, VectorFeeTypesCount)
 	for i, v := range vec {
 		result[i] = v - other[i]
 	}
@@ -236,7 +239,7 @@ func (vec VectorGasLimit) VectorSubtract(other VectorGasLimit) VectorGasLimit {
 }
 
 func (vec VectorGasLimit) VectorSubtractClampAtZero(other VectorGasLimit) VectorGasLimit {
-	var result VectorGasLimit
+	result := make(VectorGasLimit, VectorFeeTypesCount)
 	for i, v := range vec {
 		if v <= other[i] {
 			result[i] = 0

--- a/core/types/vector_fee.go
+++ b/core/types/vector_fee.go
@@ -42,6 +42,24 @@ func (vec VectorFeeBigint) Sum() *big.Int {
 	return sum
 }
 
+func (vec VectorFeeBigint) VectorAllEq(other VectorFeeBigint) bool {
+	for i, v := range vec {
+		if bothValuesNil := v == nil && other[i] == nil; bothValuesNil {
+			continue
+		}
+
+		if onlyOneOfTheValuesNil := v == nil || other[i] == nil; onlyOneOfTheValuesNil {
+			return false
+		}
+
+		if v.Cmp(other[i]) != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (vec VectorFeeBigint) VectorAllLessOrEqual(other VectorFeeBigint) bool {
 	for i, v := range vec {
 		if bothValuesNil := v == nil && other[i] == nil; bothValuesNil {
@@ -181,6 +199,16 @@ func (vec VectorGasLimit) ToVectorBigInt() VectorFeeBigint {
 	}
 
 	return result
+}
+
+func (vec VectorGasLimit) VectorAllEq(other VectorGasLimit) bool {
+	for i, v := range vec {
+		if v != other[i] {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (vec VectorGasLimit) VectorAdd(other VectorGasLimit) VectorGasLimit {

--- a/core/types/vector_fee.go
+++ b/core/types/vector_fee.go
@@ -241,16 +241,6 @@ func (vec VectorGasLimit) VectorAdd(other VectorGasLimit) VectorGasLimit {
 	return result
 }
 
-// VectorSubtract subtracts corresponding elements of other from vec.
-// Note: Does not check for underflow.
-func (vec VectorGasLimit) VectorSubtract(other VectorGasLimit) VectorGasLimit {
-	result := make(VectorGasLimit, VectorFeeTypesCount)
-	for i, v := range vec {
-		result[i] = v - other[i]
-	}
-	return result
-}
-
 // VectorSubtractClampAtZero subtracts corresponding elements of other from vec,
 // clamping results at zero if they would be negative.
 func (vec VectorGasLimit) VectorSubtractClampAtZero(other VectorGasLimit) VectorGasLimit {

--- a/core/types/vector_fee.go
+++ b/core/types/vector_fee.go
@@ -183,10 +183,32 @@ func (vec VectorGasLimit) ToVectorBigInt() VectorFeeBigint {
 	return result
 }
 
+func (vec VectorGasLimit) VectorAdd(other VectorGasLimit) VectorGasLimit {
+	var result VectorGasLimit
+	for i, v := range vec {
+		result[i] = v + other[i]
+	}
+
+	return result
+}
+
 func (vec VectorGasLimit) VectorSubtract(other VectorGasLimit) VectorGasLimit {
 	var result VectorGasLimit
 	for i, v := range vec {
 		result[i] = v - other[i]
+	}
+
+	return result
+}
+
+func (vec VectorGasLimit) VectorSubtractClampAtZero(other VectorGasLimit) VectorGasLimit {
+	var result VectorGasLimit
+	for i, v := range vec {
+		if v <= other[i] {
+			result[i] = 0
+		} else {
+			result[i] = v - other[i]
+		}
 	}
 
 	return result

--- a/core/types/vector_fee.go
+++ b/core/types/vector_fee.go
@@ -11,6 +11,12 @@ type (
 	VectorGasLimit  [3]uint64
 )
 
+const (
+	ExecutionGasIndex = iota
+	BlobGasIndex
+	CalldataGasIndex
+)
+
 func NewVectorFeeBigInt() VectorFeeBigint {
 	var result VectorFeeBigint
 	for i := range result {

--- a/core/types/vector_fee_test.go
+++ b/core/types/vector_fee_test.go
@@ -1,0 +1,515 @@
+package types
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestVectorFeeBigint_ContainsNilElement(t *testing.T) {
+	tests := []struct {
+		name string
+		vec  VectorFeeBigint
+		want bool
+	}{
+		{
+			name: "no nil elements",
+			vec: VectorFeeBigint{
+				big.NewInt(1),
+				big.NewInt(2),
+				big.NewInt(3),
+			},
+			want: false,
+		},
+		{
+			name: "one nil element",
+			vec: VectorFeeBigint{
+				big.NewInt(1),
+				nil,
+				big.NewInt(3),
+			},
+			want: true,
+		},
+		{
+			name: "all nil elements",
+			vec: VectorFeeBigint{
+				nil,
+				nil,
+				nil,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.vec.ContainsNilElement(); got != tt.want {
+				t.Errorf("ContainsNilElement() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVectorFeeBigint_VectorAllNil(t *testing.T) {
+	tests := []struct {
+		name string
+		vec  VectorFeeBigint
+		want bool
+	}{
+		{
+			name: "no nil elements",
+			vec: VectorFeeBigint{
+				big.NewInt(1),
+				big.NewInt(2),
+				big.NewInt(3),
+			},
+			want: false,
+		},
+		{
+			name: "some nil elements",
+			vec: VectorFeeBigint{
+				big.NewInt(1),
+				nil,
+				big.NewInt(3),
+			},
+			want: false,
+		},
+		{
+			name: "all nil elements",
+			vec: VectorFeeBigint{
+				nil,
+				nil,
+				nil,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.vec.VectorAllNil(); got != tt.want {
+				t.Errorf("VectorAllNil() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func TestVectorFeeBigint_VectorCopy(t *testing.T) {
+	tests := []struct {
+		name string
+		vec  VectorFeeBigint
+	}{
+		{
+			name: "all non-nil elements",
+			vec: VectorFeeBigint{
+				big.NewInt(1),
+				big.NewInt(2),
+				big.NewInt(3),
+			},
+		},
+		{
+			name: "some nil elements",
+			vec: VectorFeeBigint{
+				big.NewInt(1),
+				nil,
+				big.NewInt(3),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			copy := tt.vec.VectorCopy()
+			if !tt.vec.VectorAllEq(copy) {
+				t.Error("Copy not equal to original")
+			}
+
+			// Modify copy to ensure deep copy
+			for _, v := range copy {
+				if v != nil {
+					v.Add(v, big.NewInt(1))
+				}
+			}
+			if tt.vec.VectorAllEq(copy) {
+				t.Error("Modified copy should not be equal to original")
+			}
+		})
+	}
+}
+
+func TestVectorFeeBigint_Sum(t *testing.T) {
+	tests := []struct {
+		name    string
+		vec     VectorFeeBigint
+		want    *big.Int
+		wantErr bool
+	}{
+		{
+			name: "valid sum",
+			vec: VectorFeeBigint{
+				big.NewInt(1),
+				big.NewInt(2),
+				big.NewInt(3),
+			},
+			want:    big.NewInt(6),
+			wantErr: false,
+		},
+		{
+			name: "contains nil",
+			vec: VectorFeeBigint{
+				big.NewInt(1),
+				nil,
+				big.NewInt(3),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.vec.Sum()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Sum() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.Cmp(tt.want) != 0 {
+				t.Errorf("Sum() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVectorFeeBigint_VectorAllEq(t *testing.T) {
+	tests := []struct {
+		name   string
+		vec1   VectorFeeBigint
+		vec2   VectorFeeBigint
+		result bool
+	}{
+		{
+			name:   "equal vectors",
+			vec1:   VectorFeeBigint{big.NewInt(1), big.NewInt(2), big.NewInt(3)},
+			vec2:   VectorFeeBigint{big.NewInt(1), big.NewInt(2), big.NewInt(3)},
+			result: true,
+		},
+		{
+			name:   "unequal vectors",
+			vec1:   VectorFeeBigint{big.NewInt(1), big.NewInt(2), big.NewInt(3)},
+			vec2:   VectorFeeBigint{big.NewInt(1), big.NewInt(2), big.NewInt(4)},
+			result: false,
+		},
+		{
+			name:   "both nil elements",
+			vec1:   VectorFeeBigint{big.NewInt(1), nil, big.NewInt(3)},
+			vec2:   VectorFeeBigint{big.NewInt(1), nil, big.NewInt(3)},
+			result: true,
+		},
+		{
+			name:   "one nil element",
+			vec1:   VectorFeeBigint{big.NewInt(1), nil, big.NewInt(3)},
+			vec2:   VectorFeeBigint{big.NewInt(1), big.NewInt(2), big.NewInt(3)},
+			result: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.vec1.VectorAllEq(tt.vec2); got != tt.result {
+				t.Errorf("VectorAllEq() = %v, want %v", got, tt.result)
+			}
+		})
+	}
+}
+
+func TestVectorFeeBigint_VectorAllLessOrEqual(t *testing.T) {
+	tests := []struct {
+		name   string
+		vec1   VectorFeeBigint
+		vec2   VectorFeeBigint
+		result bool
+	}{
+		{
+			name:   "all less",
+			vec1:   VectorFeeBigint{big.NewInt(1), big.NewInt(2), big.NewInt(3)},
+			vec2:   VectorFeeBigint{big.NewInt(2), big.NewInt(3), big.NewInt(4)},
+			result: true,
+		},
+		{
+			name:   "all equal",
+			vec1:   VectorFeeBigint{big.NewInt(1), big.NewInt(2), big.NewInt(3)},
+			vec2:   VectorFeeBigint{big.NewInt(1), big.NewInt(2), big.NewInt(3)},
+			result: true,
+		},
+		{
+			name:   "one greater",
+			vec1:   VectorFeeBigint{big.NewInt(1), big.NewInt(3), big.NewInt(3)},
+			vec2:   VectorFeeBigint{big.NewInt(2), big.NewInt(2), big.NewInt(4)},
+			result: false,
+		},
+		{
+			name:   "with nil elements",
+			vec1:   VectorFeeBigint{big.NewInt(1), nil, big.NewInt(3)},
+			vec2:   VectorFeeBigint{big.NewInt(2), big.NewInt(2), big.NewInt(4)},
+			result: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.vec1.VectorAllLessOrEqual(tt.vec2); got != tt.result {
+				t.Errorf("VectorAllLessOrEqual() = %v, want %v", got, tt.result)
+			}
+		})
+	}
+}
+
+func TestVectorFeeBigint_VectorOperations(t *testing.T) {
+	tests := []struct {
+		name         string
+		vec1         VectorFeeBigint
+		vec2         VectorFeeBigint
+		wantAdd      VectorFeeBigint
+		wantMul      VectorFeeBigint
+		wantSub      VectorFeeBigint
+		wantSubClamp VectorFeeBigint
+		wantErr      bool
+	}{
+		{
+			name:         "valid operations",
+			vec1:         VectorFeeBigint{big.NewInt(1), big.NewInt(3), big.NewInt(5)},
+			vec2:         VectorFeeBigint{big.NewInt(2), big.NewInt(3), big.NewInt(4)},
+			wantAdd:      VectorFeeBigint{big.NewInt(3), big.NewInt(6), big.NewInt(9)},
+			wantMul:      VectorFeeBigint{big.NewInt(2), big.NewInt(9), big.NewInt(20)},
+			wantSub:      VectorFeeBigint{big.NewInt(-1), big.NewInt(0), big.NewInt(1)},
+			wantSubClamp: VectorFeeBigint{big.NewInt(0), big.NewInt(0), big.NewInt(1)},
+			wantErr:      false,
+		},
+		{
+			name:    "with nil elements",
+			vec1:    VectorFeeBigint{big.NewInt(1), nil, big.NewInt(3)},
+			vec2:    VectorFeeBigint{big.NewInt(2), big.NewInt(3), big.NewInt(4)},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test Add
+			resultAdd, err := tt.vec1.VectorAdd(tt.vec2)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("VectorAdd() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !tt.wantAdd.VectorAllEq(resultAdd) {
+				t.Error("VectorAdd() result not equal to expected")
+			}
+
+			// Test Multiply
+			resultMul, err := tt.vec1.VectorMul(tt.vec2)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("VectorMul() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !tt.wantMul.VectorAllEq(resultMul) {
+				t.Error("VectorMul() result not equal to expected")
+			}
+
+			// Test Subtract
+			resultSub, err := tt.vec1.VectorSubtract(tt.vec2)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("VectorSubtract() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !tt.wantSub.VectorAllEq(resultSub) {
+				t.Error("VectorSubtract() result not equal to expected")
+			}
+
+			// Test Subtract Clamp at zero
+			resultSubClamp, err := tt.vec1.VectorSubtractClampAtZero(tt.vec2)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("VectorSubtractClampAtZero() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !tt.wantSubClamp.VectorAllEq(resultSubClamp) {
+				t.Error("VectorSubtractClampAtZero() result not equal to expected")
+			}
+		})
+	}
+}
+
+func TestVectorFeeBigint_BitLengthChecks(t *testing.T) {
+	bigNum := new(big.Int).Lsh(big.NewInt(1), 257) // 2^257
+
+	tests := []struct {
+		name             string
+		vec              VectorFeeBigint
+		wantAllZero      bool
+		wantAllLessEq256 bool
+	}{
+		{
+			name: "all zero",
+			vec: VectorFeeBigint{
+				big.NewInt(0),
+				big.NewInt(0),
+				big.NewInt(0),
+			},
+			wantAllZero:      true,
+			wantAllLessEq256: true,
+		},
+		{
+			name: "some non-zero, all <= 256",
+			vec: VectorFeeBigint{
+				big.NewInt(1),
+				big.NewInt(0),
+				nil,
+			},
+			wantAllZero:      false,
+			wantAllLessEq256: true,
+		},
+		{
+			name: "with large number",
+			vec: VectorFeeBigint{
+				big.NewInt(1),
+				bigNum,
+				big.NewInt(0),
+			},
+			wantAllZero:      false,
+			wantAllLessEq256: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.vec.VecBitLenAllZero(); got != tt.wantAllZero {
+				t.Errorf("VecBitLenAllZero() = %v, want %v", got, tt.wantAllZero)
+			}
+			if got := tt.vec.VecBitLenAllLessEqThan256(); got != tt.wantAllLessEq256 {
+				t.Errorf("VecBitLenAllLessEqThan256() = %v, want %v", got, tt.wantAllLessEq256)
+			}
+		})
+	}
+}
+
+func TestVectorGasLimit_Operations(t *testing.T) {
+	tests := []struct {
+		name         string
+		vec1         VectorGasLimit
+		vec2         VectorGasLimit
+		wantAdd      VectorGasLimit
+		wantSub      VectorGasLimit
+		wantSubClamp VectorGasLimit
+	}{
+		{
+			name:         "basic operations",
+			vec1:         VectorGasLimit{100, 200, 300},
+			vec2:         VectorGasLimit{50, 100, 150},
+			wantAdd:      VectorGasLimit{150, 300, 450},
+			wantSub:      VectorGasLimit{50, 100, 150},
+			wantSubClamp: VectorGasLimit{50, 100, 150},
+		},
+		{
+			name:         "with clamping",
+			vec1:         VectorGasLimit{100, 200, 300},
+			vec2:         VectorGasLimit{150, 250, 250},
+			wantAdd:      VectorGasLimit{250, 450, 550},
+			wantSubClamp: VectorGasLimit{0, 0, 50},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resultAdd := tt.vec1.VectorAdd(tt.vec2)
+			if !resultAdd.VectorAllEq(tt.wantAdd) {
+				t.Errorf("VectorAdd() = %v, want %v", resultAdd, tt.wantAdd)
+			}
+
+			resultSubClamp := tt.vec1.VectorSubtractClampAtZero(tt.vec2)
+			if !resultSubClamp.VectorAllEq(tt.wantSubClamp) {
+				t.Errorf("VectorSubtractClampAtZero() = %v, want %v", resultSubClamp, tt.wantSubClamp)
+			}
+		})
+	}
+}
+
+func TestVectorGasLimit_ToVectorBigInt(t *testing.T) {
+	tests := []struct {
+		name string
+		vec  VectorGasLimit
+		want VectorFeeBigint
+	}{
+		{
+			name: "basic conversion",
+			vec:  VectorGasLimit{100, 200, 300},
+			want: VectorFeeBigint{
+				big.NewInt(100),
+				big.NewInt(200),
+				big.NewInt(300),
+			},
+		},
+		{
+			name: "zero values",
+			vec:  VectorGasLimit{0, 0, 0},
+			want: VectorFeeBigint{
+				big.NewInt(0),
+				big.NewInt(0),
+				big.NewInt(0),
+			},
+		},
+		{
+			name: "max uint64",
+			vec:  VectorGasLimit{^uint64(0), ^uint64(0), ^uint64(0)},
+			want: VectorFeeBigint{
+				new(big.Int).SetUint64(^uint64(0)),
+				new(big.Int).SetUint64(^uint64(0)),
+				new(big.Int).SetUint64(^uint64(0)),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.vec.ToVectorBigInt()
+			if !got.VectorAllEq(tt.want) {
+				t.Errorf("ToVectorBigInt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVectorGasLimit_VectorAllEq(t *testing.T) {
+	tests := []struct {
+		name string
+		vec1 VectorGasLimit
+		vec2 VectorGasLimit
+		want bool
+	}{
+		{
+			name: "equal vectors",
+			vec1: VectorGasLimit{100, 200, 300},
+			vec2: VectorGasLimit{100, 200, 300},
+			want: true,
+		},
+		{
+			name: "unequal vectors",
+			vec1: VectorGasLimit{100, 200, 300},
+			vec2: VectorGasLimit{100, 200, 301},
+			want: false,
+		},
+		{
+			name: "zero vectors",
+			vec1: VectorGasLimit{0, 0, 0},
+			vec2: VectorGasLimit{0, 0, 0},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.vec1.VectorAllEq(tt.vec2); got != tt.want {
+				t.Errorf("VectorAllEq() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -75,10 +75,12 @@ type BlockContext struct {
 // All fields can change between transactions.
 type TxContext struct {
 	// Message information
-	Origin       common.Address      // Provides information for ORIGIN
-	GasPrice     *big.Int            // Provides information for GASPRICE (and is used to zero the basefee if NoBaseFee is set)
-	BlobHashes   []common.Hash       // Provides information for BLOBHASH
-	BlobFeeCap   *big.Int            // Is used to zero the blobbasefee if NoBaseFee is set
+	Origin     common.Address // Provides information for ORIGIN
+	GasPrice   *big.Int       // Provides information for GASPRICE (and is used to zero the basefee if NoBaseFee is set)
+	BlobHashes []common.Hash  // Provides information for BLOBHASH
+	//[rollup-geth]NOTE: as far as I can see  this zeroing out is only done in gasestimator/gasestimator.go
+	// Is used to zero the blobbasefee if NoBaseFee is set
+	BlobFeeCap   *big.Int
 	AccessEvents *state.AccessEvents // Capture all state accesses for this tx
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -66,8 +66,7 @@ type BlockContext struct {
 	BlobBaseFee *big.Int       // Provides information for BLOBBASEFEE (0 if vm runs with NoBaseFee flag and 0 blob gas price)
 	Random      *common.Hash   // Provides information for PREVRANDAO
 
-	//[rollup-geth]
-	//TODO: where do we set this?
+	//[rollup-geth] EIP-7706
 	BaseFees types.VectorFeeBigint
 }
 
@@ -78,8 +77,9 @@ type TxContext struct {
 	Origin     common.Address // Provides information for ORIGIN
 	GasPrice   *big.Int       // Provides information for GASPRICE (and is used to zero the basefee if NoBaseFee is set)
 	BlobHashes []common.Hash  // Provides information for BLOBHASH
-	//[rollup-geth]NOTE: as far as I can see  this zeroing out is only done in gasestimator/gasestimator.go
 	// Is used to zero the blobbasefee if NoBaseFee is set
+	//NOTE: [rollup-geth] as far as I can see  this zeroing out is only done in gasestimator/gasestimator.go
+	//TODO: [rollup-geth] EIP-7706 do we need to zero-out vector of FeeCaps?
 	BlobFeeCap   *big.Int
 	AccessEvents *state.AccessEvents // Capture all state accesses for this tx
 }

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -40,6 +40,9 @@ func NewEnv(cfg *Config) *vm.EVM {
 		BaseFee:     cfg.BaseFee,
 		BlobBaseFee: cfg.BlobBaseFee,
 		Random:      cfg.Random,
+
+		//[rollup-geth] EIP-7706
+		BaseFees: cfg.BaseFees,
 	}
 
 	return vm.NewEVM(blockContext, txContext, cfg.State, cfg.ChainConfig, cfg.EVMConfig)

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -51,6 +51,9 @@ type Config struct {
 
 	State     *state.StateDB
 	GetHashFn func(n uint64) common.Hash
+
+	//[rollup-geth] EIP-7706
+	BaseFees types.VectorFeeBigint
 }
 
 // sets defaults on the config
@@ -107,8 +110,13 @@ func setDefaults(cfg *Config) {
 		cfg.BaseFee = big.NewInt(params.InitialBaseFee)
 	}
 	if cfg.BlobBaseFee == nil {
-		cfg.BlobBaseFee = big.NewInt(params.BlobTxMinBlobGasprice)
+		cfg.BlobBaseFee = big.NewInt(params.TxMinGasPrice)
 	}
+
+	if cfg.BaseFees.VectorAllNil() {
+		cfg.BaseFees = types.VectorFeeBigint{big.NewInt(params.InitialBaseFee), big.NewInt(params.TxMinGasPrice), big.NewInt(params.TxMinGasPrice)}
+	}
+
 	// Merge indicators
 	if t := cfg.ChainConfig.ShanghaiTime; cfg.ChainConfig.TerminalTotalDifficultyPassed || (t != nil && *t == 0) {
 		cfg.Random = &(common.Hash{})

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -46,6 +46,7 @@ type Options struct {
 	ErrorRatio float64 // Allowed overestimation ratio for faster estimation termination
 }
 
+// TODO: [rollup-geth] EIP-7706
 // Estimate returns the lowest possible gas limit that allows the transaction to
 // run successfully with the provided context options. It returns an error if the
 // transaction would always revert, or if there are unexpected failures.

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -90,6 +90,7 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	if bf.results.baseFee = bf.header.BaseFee; bf.results.baseFee == nil {
 		bf.results.baseFee = new(big.Int)
 	}
+	//TODO:[rollup-geth] what about EIP-7706 base fees?
 	if config.IsLondon(big.NewInt(int64(bf.blockNumber + 1))) {
 		bf.results.nextBaseFee = eip1559.CalcBaseFee(config, bf.header)
 	} else {

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -253,7 +253,8 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 	signer := types.MakeSigner(eth.blockchain.Config(), block.Number(), block.Time())
 	for idx, tx := range block.Transactions() {
 		// Assemble the transaction call message and return if the requested offset
-		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
+		// [rollup-geth] EIP-7706
+		msg, _ := core.TransactionToMessage(tx, signer, block.Header(), eth.blockchain.Config())
 		txContext := core.NewEVMTxContext(msg)
 		context := core.NewEVMBlockContext(block.Header(), eth.blockchain, nil)
 		if idx == txIndex {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -271,7 +271,8 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				)
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
-					msg, _ := core.TransactionToMessage(tx, signer, task.block.BaseFee())
+					//[rollup-geth] EIP-7706
+					msg, _ := core.TransactionToMessage(tx, signer, task.block.Header(), api.backend.ChainConfig())
 					txctx := &Context{
 						BlockHash:   task.block.Hash(),
 						BlockNumber: task.block.Number(),
@@ -549,7 +550,8 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 			return nil, err
 		}
 		var (
-			msg, _    = core.TransactionToMessage(tx, signer, block.BaseFee())
+			//[rollup-geth] EIP-7706
+			msg, _    = core.TransactionToMessage(tx, signer, block.Header(), chainConfig)
 			txContext = core.NewEVMTxContext(msg)
 			vmenv     = vm.NewEVM(vmctx, txContext, statedb, chainConfig, vm.Config{})
 		)
@@ -629,7 +631,8 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	}
 	for i, tx := range txs {
 		// Generate the next state snapshot fast without tracing
-		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
+		//[rollup-geth] EIP-7706
+		msg, _ := core.TransactionToMessage(tx, signer, block.Header(), api.backend.ChainConfig())
 		txctx := &Context{
 			BlockHash:   blockHash,
 			BlockNumber: block.Number(),
@@ -668,7 +671,8 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 			defer pend.Done()
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
-				msg, _ := core.TransactionToMessage(txs[task.index], signer, block.BaseFee())
+				//[rollup-geth] EIP-7706
+				msg, _ := core.TransactionToMessage(txs[task.index], signer, block.Header(), api.backend.ChainConfig())
 				txctx := &Context{
 					BlockHash:   blockHash,
 					BlockNumber: block.Number(),
@@ -705,7 +709,8 @@ txloop:
 		}
 
 		// Generate the next state snapshot fast without tracing
-		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
+		//[rollup-geth] EIP-7706
+		msg, _ := core.TransactionToMessage(tx, signer, block.Header(), api.backend.ChainConfig())
 		statedb.SetTxContext(tx.Hash(), i)
 		vmenv := vm.NewEVM(blockCtx, core.NewEVMTxContext(msg), statedb, api.backend.ChainConfig(), vm.Config{})
 		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit)); err != nil {
@@ -792,7 +797,8 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	for i, tx := range block.Transactions() {
 		// Prepare the transaction for un-traced execution
 		var (
-			msg, _    = core.TransactionToMessage(tx, signer, block.BaseFee())
+			//[rollup-geth] EIP-7706
+			msg, _    = core.TransactionToMessageEIP4844(tx, signer, block.BaseFee())
 			txContext = core.NewEVMTxContext(msg)
 			vmConf    vm.Config
 			dump      *os.File
@@ -890,7 +896,9 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 		return nil, err
 	}
 	defer release()
-	msg, err := core.TransactionToMessage(tx, types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time()), block.BaseFee())
+
+	//[rollup-geth] EIP-7706
+	msg, err := core.TransactionToMessage(tx, types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time()), block.Header(), api.backend.ChainConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -171,7 +171,7 @@ func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(b.chainConfig, block.Number(), block.Time())
 	for idx, tx := range block.Transactions() {
-		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
+		msg, _ := core.TransactionToMessageEIP4844(tx, signer, block.BaseFee())
 		txContext := core.NewEVMTxContext(msg)
 		context := core.NewEVMBlockContext(block.Header(), b.chain, nil)
 		if idx == txIndex {

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -276,7 +276,7 @@ func TestInternals(t *testing.T) {
 			Difficulty:  big.NewInt(0x30000),
 			GasLimit:    uint64(6000000),
 			BaseFee:     new(big.Int),
-			BaseFees:    types.NewVectorFeeBigInt(),
+			BaseFees:    make(types.VectorFeeBigint, types.VectorFeeTypesCount),
 		}
 	)
 	mkTracer := func(name string, cfg json.RawMessage) *tracers.Tracer {

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -127,7 +127,10 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			}
 
 			state.StateDB.SetLogger(tracer.Hooks)
-			msg, err := core.TransactionToMessage(tx, signer, context.BaseFee)
+
+			//[rollup-geth] EIP-7706
+			msg, err := core.TransactionToMessageEIP4844(tx, signer, context.BaseFee)
+
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}
@@ -219,7 +222,17 @@ func benchTracer(tracerName string, test *callTracerTest, b *testing.B) {
 		Difficulty:  (*big.Int)(test.Context.Difficulty),
 		GasLimit:    uint64(test.Context.GasLimit),
 	}
-	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee)
+
+	//[rollup-geth] EIP-7706
+	var (
+		msg *core.Message
+		err error
+	)
+	if test.Genesis.Config.IsEIP7706(context.BlockNumber, context.Time) {
+		msg, err = core.TransactionToMessageEIP7706(tx, signer, context.BaseFees)
+	} else {
+		msg, err = core.TransactionToMessageEIP4844(tx, signer, context.BaseFee)
+	}
 	if err != nil {
 		b.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
@@ -263,6 +276,7 @@ func TestInternals(t *testing.T) {
 			Difficulty:  big.NewInt(0x30000),
 			GasLimit:    uint64(6000000),
 			BaseFee:     new(big.Int),
+			BaseFees:    types.NewVectorFeeBigInt(),
 		}
 	)
 	mkTracer := func(name string, cfg json.RawMessage) *tracers.Tracer {
@@ -376,7 +390,14 @@ func TestInternals(t *testing.T) {
 				GasPrice: tx.GasPrice(),
 			}
 			evm := vm.NewEVM(context, txContext, state.StateDB, config, vm.Config{Tracer: tc.tracer.Hooks})
-			msg, err := core.TransactionToMessage(tx, signer, big.NewInt(0))
+
+			//[rollup-geth] EIP-7706
+			var msg *core.Message
+			if config.IsEIP7706(context.BlockNumber, context.Time) {
+				msg, err = core.TransactionToMessageEIP7706(tx, signer, context.BaseFees)
+			} else {
+				msg, err = core.TransactionToMessageEIP4844(tx, signer, context.BaseFee)
+			}
 			if err != nil {
 				t.Fatalf("test %v: failed to create message: %v", tc.name, err)
 			}

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -95,7 +95,8 @@ func flatCallTracerTestRunner(tracerName string, filename string, dirPath string
 	}
 
 	state.StateDB.SetLogger(tracer.Hooks)
-	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee)
+	//[rollup-geth] EIP-7706
+	msg, err := core.TransactionToMessageEIP4844(tx, signer, context.BaseFee)
 	if err != nil {
 		return fmt.Errorf("failed to prepare transaction for tracing: %v", err)
 	}

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -104,7 +104,8 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 			}
 
 			state.StateDB.SetLogger(tracer.Hooks)
-			msg, err := core.TransactionToMessage(tx, signer, context.BaseFee)
+			//[rollup-geth] EIP-7706
+			msg, err := core.TransactionToMessageEIP4844(tx, signer, context.BaseFee)
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}

--- a/eth/tracers/internal/tracetest/util.go
+++ b/eth/tracers/internal/tracetest/util.go
@@ -34,6 +34,7 @@ type callContext struct {
 	BaseFee    *math.HexOrDecimal256 `json:"baseFeePerGas"`
 }
 
+// TODO: [rollup-geth] EIP-7706 add and map missing fields
 func (c *callContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
 	context := vm.BlockContext{
 		CanTransfer: core.CanTransfer,

--- a/eth/tracers/live/supply.go
+++ b/eth/tracers/live/supply.go
@@ -140,6 +140,7 @@ func (s *supply) OnBlockStart(ev tracing.BlockEvent) {
 	s.delta.ParentHash = ev.Block.ParentHash()
 
 	// Calculate Burn for this block
+	//TODO: [rollup-geth] EIP-7706
 	if ev.Block.BaseFee() != nil {
 		burn := new(big.Int).Mul(new(big.Int).SetUint64(ev.Block.GasUsed()), ev.Block.BaseFee())
 		s.delta.Burn.EIP1559 = burn

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -90,7 +90,7 @@ func BenchmarkTransactionTrace(b *testing.B) {
 		//EnableReturnData: false,
 	})
 	evm := vm.NewEVM(context, txContext, state.StateDB, params.AllEthashProtocolChanges, vm.Config{Tracer: tracer.Hooks()})
-	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee)
+	msg, err := core.TransactionToMessageEIP4844(tx, signer, context.BaseFee)
 	if err != nil {
 		b.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -773,6 +773,7 @@ func (b *Block) NextBaseFeePerGas(ctx context.Context) (*hexutil.Big, error) {
 			return nil, nil
 		}
 	}
+	//TODO:[rollup-geth] what about EIP-7706 base fees?
 	nextBaseFee := eip1559.CalcBaseFee(chaincfg, header)
 	return (*hexutil.Big)(nextBaseFee), nil
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -156,6 +156,8 @@ type CallMsg struct {
 	// For BlobTxType
 	BlobGasFeeCap *big.Int
 	BlobHashes    []common.Hash
+
+	//TODO: [rollup-geth] add EIP-7706 missing fields
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1051,6 +1051,7 @@ func (diff *StateOverride) Apply(statedb *state.StateDB, precompiles vm.Precompi
 	return nil
 }
 
+// TODO: [rollup-geth] EIP-7706 add missing fields
 // BlockOverrides is a set of header fields to override.
 type BlockOverrides struct {
 	Number        *hexutil.Big

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1564,6 +1564,7 @@ func NewRPCPendingTransaction(tx *types.Transaction, current *types.Header, conf
 		blockNumber = uint64(0)
 		blockTime   = uint64(0)
 	)
+	//TODO:[rollup-geth] what about EIP-7706 base fees?
 	if current != nil {
 		baseFee = eip1559.CalcBaseFee(config, current)
 		blockNumber = current.Number.Uint64()

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -148,6 +148,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		// In non-validation mode base fee is set to 0 if it is not overridden.
 		// This is because it creates an edge case in EVM where gasPrice < baseFee.
 		// Base fee could have been overridden.
+		//TODO:[rollup-geth] what about EIP-7706 base fees?
 		if header.BaseFee == nil {
 			if sim.validate {
 				header.BaseFee = eip1559.CalcBaseFee(sim.chainConfig, parent)

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -291,6 +291,7 @@ func (args *TransactionArgs) setLondonFeeDefaults(ctx context.Context, head *typ
 	return nil
 }
 
+// TODO: [rollup-geth] set EIP-7706 defaults
 // setBlobTxSidecar adds the blob tx
 func (args *TransactionArgs) setBlobTxSidecar(ctx context.Context) error {
 	// No blobs, we're done.

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -74,6 +74,8 @@ type TransactionArgs struct {
 
 	// This configures whether blobs are allowed to be passed.
 	blobSidecarAllowed bool
+
+	//TODO: [rollup-geth] add EIP-7706 missing fields
 }
 
 // from retrieves the transaction sender address.
@@ -417,6 +419,7 @@ func (args *TransactionArgs) CallDefaults(globalGasCap uint64, baseFee *big.Int,
 	return nil
 }
 
+// TODO: [rollup-geth] EIP-7706
 // ToMessage converts the transaction arguments to the Message type used by the
 // core evm. This method is used in calls and traces that do not require a real
 // live transaction.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -210,13 +210,9 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 	if miner.chainConfig.IsEIP7706(header.Number, header.Time) {
 		parentGasUsed, parentExcessGas, parentGasLimits := eip7706.SanitizeEIP7706Fields(parent)
 
-		excessGas := eip7706.CalcExecGas(parentGasUsed, parentExcessGas, parentGasLimits)
-		gasLimits := core.CalcGasLimits(parent.GasLimit, miner.config.GasCeil)
-		baseFees := eip7706.CalcBaseFees(parentExcessGas, parentGasLimits)
-
-		header.ExcessGas = &excessGas
-		header.GasLimits = &gasLimits
-		header.BaseFees = &baseFees
+		header.ExcessGas = eip7706.CalcExecGas(parentGasUsed, parentExcessGas, parentGasLimits)
+		header.GasLimits = core.CalcGasLimits(parent.GasLimit, miner.config.GasCeil)
+		header.BaseFees = eip7706.CalcBaseFees(parentExcessGas, parentGasLimits)
 	}
 
 	// Could potentially happen if starting to mine in an odd state.

--- a/params/config.go
+++ b/params/config.go
@@ -343,6 +343,9 @@ type ChainConfig struct {
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty"`
 	Clique *CliqueConfig `json:"clique,omitempty"`
+
+	//[rollup-geth] specific config
+	EIP7706Time *uint64 `json:"eip7706Time,omitempty"` // EIP-7706 (vector fees), switch tim e(nil = no fork, 0 already activated)
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -559,11 +562,6 @@ func (c *ChainConfig) IsVerkle(num *big.Int, time uint64) bool {
 // IsEIP4762 returns whether eip 4762 has been activated at given block.
 func (c *ChainConfig) IsEIP4762(num *big.Int, time uint64) bool {
 	return c.IsVerkle(num, time)
-}
-
-// [rollup-geth]
-func (c *ChainConfig) IsR0() bool {
-	return true
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
@@ -899,7 +897,9 @@ type Rules struct {
 	IsBerlin, IsLondon                                      bool
 	IsMerge, IsShanghai, IsCancun, IsPrague                 bool
 	IsVerkle                                                bool
-	IsR0                                                    bool // [rollup-geth]
+
+	//[rollup-geth]
+	IsEIP7706 bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -911,6 +911,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 	// disallow setting Merge out of order
 	isMerge = isMerge && c.IsLondon(num)
 	isVerkle := isMerge && c.IsVerkle(num, timestamp)
+
 	return Rules{
 		ChainID:          new(big.Int).Set(chainID),
 		IsHomestead:      c.IsHomestead(num),
@@ -930,6 +931,8 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsPrague:         isMerge && c.IsPrague(num, timestamp),
 		IsVerkle:         isVerkle,
 		IsEIP4762:        isVerkle,
-		IsR0:             true, // [rollup-geth]
+
+		//[rollup-geth]
+		IsEIP7706: c.IsEIP7706(num, timestamp),
 	}
 }

--- a/params/config_rollup.go
+++ b/params/config_rollup.go
@@ -1,0 +1,8 @@
+package params
+
+import "math/big"
+
+// IsEIP4762 returns whether eip 4762 has been activated at given block.
+func (c *ChainConfig) IsEIP7706(num *big.Int, time uint64) bool {
+	return isTimestampForked(c.EIP7706Time, time)
+}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -168,7 +168,6 @@ const (
 	BlobTxBytesPerFieldElement         = 32      // Size in bytes of a field element
 	BlobTxFieldElementsPerBlob         = 4096    // Number of field elements stored in a single data blob
 	BlobTxBlobGasPerBlob               = 1 << 17 // Gas consumption of a single data blob (== blob byte size)
-	BlobTxMinBlobGasprice              = 1       // Minimum gas price for data blobs
 	BlobTxBlobGaspriceUpdateFraction   = 3338477 // Controls the maximum rate of change for blob gas price
 	BlobTxPointEvaluationPrecompileGas = 50000   // Gas price for the point evaluation precompile.
 
@@ -179,6 +178,9 @@ const (
 
 	CalldataTokensPerNonZeroByte = 4
 	CalldataGasPerToken          = 4
+
+	//[rollup-geth] EIP-7706
+	TxMinGasPrice = 1 // Minimum gas price
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -175,12 +175,6 @@ const (
 	MaxBlobGasPerBlock          = 6 * BlobTxBlobGasPerBlob // Maximum consumable blob gas for data blobs per block
 
 	HistoryServeWindow = 8192 // Number of blocks to serve historical block hashes for, EIP-2935.
-
-	CalldataTokensPerNonZeroByte = 4
-	CalldataGasPerToken          = 4
-
-	//[rollup-geth] EIP-7706
-	TxMinGasPrice = 1 // Minimum gas price
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations

--- a/params/protocol_params_rollup.go
+++ b/params/protocol_params_rollup.go
@@ -1,0 +1,13 @@
+package params
+
+const (
+	//EIP-7706
+	TxMinGasPrice                = 1 // Minimum gas price
+	CalldataTokensPerNonZeroByte = 4
+	CalldataGasPerToken          = 4
+	CallDataGasLimitRatio        = 4
+	BaseFeeUpdateFraction        = 8
+)
+
+// EIP-7706
+var LimitTargetRatios = [3]uint64{2, 2, 4}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -238,6 +238,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	block := t.genesis(config).ToBlock()
 	st = MakePreState(rawdb.NewMemoryDatabase(), t.json.Pre, snapshotter, scheme)
 
+	//TODO: [rollup-geth] what about EIP-7706 fields
 	var baseFee *big.Int
 	if config.IsLondon(new(big.Int)) {
 		baseFee = t.json.Env.BaseFee


### PR DESCRIPTION
This is the second PR tackling #12  ([EIP-7706](https://eips.ethereum.org/EIPS/eip-7706))

It is more packed than I initially anticipated (usually I prefer smaller contained PRs), but now it is what it is.

## Block header related changes

This PR adds EIP-7706 specific fields to the block Header (`GasLimits`, `GasUsedVector`, `ExcessGas`).
In order to validate and calculate these new EIP-7706 headers, the changes to both `consensus` and `miner/worker.go` were made.

- `consensus/misc/eip7706` was added to follow EIP-1559 and EIP-4844 changes. Here is the implemented logic for both EIP-7706 header validation as well as calculation of newly added gas fields 
- `worker.go` is in charge of building new blocks, so here is where the header is being "assembled"

## Other

### All the todos
The file count is huge because I've added a bunch of `TODOs` to mark all the places I should look into after the core logic has been implemented. These are all the places that were modified by EIP-1559 and/or EIP-4844.

NOTE: most of these `TODOs` are around "peripheral stuff", eg. `t8ntool`, `chain_makers` (used for building various "testing blockchains"), tracers, etc. 
Since updates for most of these were not defined in EIP-7706, I'm leaving them for later on where the core logic is implemented. 

### Code cleanups
I've done a bunch of smaller and bigger cleanups

- Better handling of the EIP-7706 "activation" via `params/confg_rollup|IsEIP7706`
- Streamlined `TransactionToMessage` which builds `Message` object used to _transiton state_
- Improved error handling & cleaned up code in `state_transition`
- Changed how `types/vector_fees.go` works (interface changes), added tests, fixed bugs