### PR TITLE
[EIP-7706] Block Header - BaseFees handling

### DIFF
--- a/consensus/misc/eip7706/eip7706.go
+++ b/consensus/misc/eip7706/eip7706.go
@@ -92,7 +92,7 @@ func SanitizeEIP7706Fields(header *types.Header) (types.VectorGasLimit, types.Ve
 }
 
 // CalcBaseFeesFromParentHeader calculates base fees per EIP-7706 given parent header
-func CalcBaseFeesFromParentHeader(config *params.ChainConfig, parent *types.Header) (*types.VectorFeeBigint, error) {
+func CalcBaseFeesFromParentHeader(config *params.ChainConfig, parent *types.Header) (types.VectorFeeBigint, error) {
 	if parent == nil {
 		return nil, errors.New("parent header is nil")
 	}
@@ -105,9 +105,7 @@ func CalcBaseFeesFromParentHeader(config *params.ChainConfig, parent *types.Head
 		return nil, err
 	}
 
-	baseFees := CalcBaseFees(parent.ExcessGas, parent.GasLimits)
-
-	return &baseFees, nil
+	return CalcBaseFees(parent.ExcessGas, parent.GasLimits), nil
 }
 
 // CalcBaseFees  calculates vector of the base fees for current block header given parent excess gas and targets

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip7706"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
@@ -1777,6 +1778,14 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool, makeWitness 
 			return nil, it.index, err
 		}
 		statedb.SetLogger(bc.logger)
+
+		//[rollup-geth] EIP-7706
+		if block.BaseFees() == nil {
+			baseFees, err := eip7706.CalcBaseFeesFromParentHeader(bc.chainConfig, parent)
+			if err == nil {
+				block.SetBaseFees(baseFees)
+			}
+		}
 
 		// If we are past Byzantium, enable prefetching to pull in trie node paths
 		// while processing transactions. Before Byzantium the prefetcher is mostly

--- a/core/rawdb/accessor_chain_rollup_test.go
+++ b/core/rawdb/accessor_chain_rollup_test.go
@@ -15,7 +15,7 @@ func TestHeaderStorageIncludingBaseFees(t *testing.T) {
 
 	// Create a test header to move around the database and make sure it's really new
 	baseFees := types.VectorFeeBigint{big.NewInt(1), big.NewInt(2), big.NewInt(3)}
-	header := &types.Header{Number: big.NewInt(42), Extra: []byte("test header base fees"), BaseFees: &baseFees}
+	header := &types.Header{Number: big.NewInt(42), Extra: []byte("test header base fees"), BaseFees: baseFees}
 	if entry := ReadHeader(db, header.Hash(), header.Number.Uint64()); entry != nil {
 		t.Fatalf("Non existent header returned: %v", entry)
 	}

--- a/core/rawdb/accessor_chain_rollup_test.go
+++ b/core/rawdb/accessor_chain_rollup_test.go
@@ -1,0 +1,77 @@
+package rawdb
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"golang.org/x/crypto/sha3"
+)
+
+// Tests block header storage and retrieval operations when base fees are set
+func TestHeaderStorageIncludingBaseFees(t *testing.T) {
+	db := NewMemoryDatabase()
+
+	// Create a test header to move around the database and make sure it's really new
+	baseFees := types.VectorFeeBigint{big.NewInt(1), big.NewInt(2), big.NewInt(3)}
+	header := &types.Header{Number: big.NewInt(42), Extra: []byte("test header base fees"), BaseFees: &baseFees}
+	if entry := ReadHeader(db, header.Hash(), header.Number.Uint64()); entry != nil {
+		t.Fatalf("Non existent header returned: %v", entry)
+	}
+	// Write and verify the header in the database
+	WriteHeader(db, header)
+	if entry := ReadHeader(db, header.Hash(), header.Number.Uint64()); entry == nil {
+		t.Fatalf("Stored header not found")
+	} else if entry.Hash() != header.Hash() {
+		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, header)
+	} else if entry.BaseFees == nil {
+		t.Fatalf("Base fees are nil")
+	} else if !entry.BaseFees.VectorAllEq(baseFees) {
+		t.Fatalf("Base fees mismatch: have %v, want %v", entry.BaseFees, baseFees)
+	}
+
+	if entry := ReadHeaderRLP(db, header.Hash(), header.Number.Uint64()); entry == nil {
+		t.Fatalf("Stored header RLP not found")
+	} else {
+		hasher := sha3.NewLegacyKeccak256()
+		hasher.Write(entry)
+
+		if hash := common.BytesToHash(hasher.Sum(nil)); hash != header.Hash() {
+			t.Fatalf("Retrieved RLP header mismatch: have %v, want %v", entry, header)
+		}
+	}
+	// Delete the header and verify the execution
+	DeleteHeader(db, header.Hash(), header.Number.Uint64())
+	if entry := ReadHeader(db, header.Hash(), header.Number.Uint64()); entry != nil {
+		t.Fatalf("Deleted header returned: %v", entry)
+	}
+
+	if baseFeesEntry := ReadHeaderBaseFees(db, header.Hash()); baseFeesEntry != nil {
+		t.Fatalf("Deleted header returned base fees: %v", baseFeesEntry)
+	}
+}
+
+// Tests block header storage and retrieval operations when there are no base fees
+func TestHeaderStorageNoBaseFees(t *testing.T) {
+	db := NewMemoryDatabase()
+
+	// Create a test header to move around the database and make sure it's really new
+	header := &types.Header{Number: big.NewInt(42), Extra: []byte("test header no base fees")}
+	if entry := ReadHeader(db, header.Hash(), header.Number.Uint64()); entry != nil {
+		t.Fatalf("Non existent header returned: %v", entry)
+	}
+	// Write and verify the header in the database
+	WriteHeader(db, header)
+	if entry := ReadHeader(db, header.Hash(), header.Number.Uint64()); entry == nil {
+		t.Fatalf("Stored header not found")
+	} else if entry.Hash() != header.Hash() {
+		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, header)
+	} else if entry.BaseFees != nil {
+		t.Fatalf("Base fees are not nil")
+	}
+
+	if baseFeesEntry := ReadHeaderBaseFees(db, header.Hash()); baseFeesEntry != nil {
+		t.Fatalf("Base fees entry should not be set, returned %v", baseFeesEntry)
+	}
+}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -372,6 +372,9 @@ func ReadHeader(db ethdb.Reader, hash common.Hash, number uint64) *types.Header 
 		log.Error("Invalid block header RLP", "hash", hash, "err", err)
 		return nil
 	}
+
+	header.BaseFees = ReadHeaderBaseFees(db, hash)
+
 	return header
 }
 
@@ -384,6 +387,7 @@ func WriteHeader(db ethdb.KeyValueWriter, header *types.Header) {
 	)
 	// Write the hash -> number mapping
 	WriteHeaderNumber(db, hash, number)
+	WriteHeaderBaseFees(db, hash, header.BaseFees)
 
 	// Write the encoded header
 	data, err := rlp.EncodeToBytes(header)
@@ -402,6 +406,7 @@ func DeleteHeader(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
 	if err := db.Delete(headerNumberKey(hash)); err != nil {
 		log.Crit("Failed to delete hash to number mapping", "err", err)
 	}
+	DeleteHeaderBaseFees(db, hash)
 }
 
 // deleteHeaderWithoutNumber removes only the block header but does not remove

--- a/core/rawdb/accessors_chain_rollup.go
+++ b/core/rawdb/accessors_chain_rollup.go
@@ -1,0 +1,49 @@
+package rawdb
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// ReadHeaderBaseFees reads the base fees for the given header (hash)
+func ReadHeaderBaseFees(db ethdb.KeyValueReader, hash common.Hash) *types.VectorFeeBigint {
+	data, _ := db.Get(headerBaseFeesKey(hash))
+	if len(data) == 0 {
+		return nil
+	}
+	dec := new(types.VectorFeeBigint)
+	err := rlp.DecodeBytes(data, dec)
+	if err != nil {
+		return nil
+	}
+
+	return dec
+}
+
+// WriteHeaderBaseFee stores the header hash->base fees mapping.
+func WriteHeaderBaseFees(db ethdb.KeyValueWriter, hash common.Hash, baseFees *types.VectorFeeBigint) {
+	if baseFees == nil {
+		//Pre-EIP-7706 blocks don't have base fees so no need to log errors
+		return
+	}
+
+	key := headerBaseFeesKey(hash)
+	enc, err := rlp.EncodeToBytes(baseFees)
+	if err != nil {
+		log.Crit("Failed to RLP encode Base Fees", "err", err)
+	}
+
+	if err = db.Put(key, enc); err != nil {
+		log.Crit("Failed to store header hash to base fees mapping", "err", err)
+	}
+}
+
+// DeleteHeaderBaseFees removes header hash -> base fees mapping
+func DeleteHeaderBaseFees(db ethdb.KeyValueWriter, hash common.Hash) {
+	if err := db.Delete(headerBaseFeesKey(hash)); err != nil {
+		log.Crit("Failed to delete header hash to base fees mapping", "err", err)
+	}
+}

--- a/core/rawdb/accessors_chain_rollup.go
+++ b/core/rawdb/accessors_chain_rollup.go
@@ -9,22 +9,23 @@ import (
 )
 
 // ReadHeaderBaseFees reads the base fees for the given header (hash)
-func ReadHeaderBaseFees(db ethdb.KeyValueReader, hash common.Hash) *types.VectorFeeBigint {
+func ReadHeaderBaseFees(db ethdb.KeyValueReader, hash common.Hash) types.VectorFeeBigint {
 	data, _ := db.Get(headerBaseFeesKey(hash))
 	if len(data) == 0 {
 		return nil
 	}
+
 	dec := new(types.VectorFeeBigint)
 	err := rlp.DecodeBytes(data, dec)
 	if err != nil {
 		return nil
 	}
 
-	return dec
+	return *dec
 }
 
 // WriteHeaderBaseFee stores the header hash->base fees mapping.
-func WriteHeaderBaseFees(db ethdb.KeyValueWriter, hash common.Hash, baseFees *types.VectorFeeBigint) {
+func WriteHeaderBaseFees(db ethdb.KeyValueWriter, hash common.Hash, baseFees types.VectorFeeBigint) {
 	if baseFees == nil {
 		//Pre-EIP-7706 blocks don't have base fees so no need to log errors
 		return

--- a/core/rawdb/schema_rollup.go
+++ b/core/rawdb/schema_rollup.go
@@ -1,0 +1,10 @@
+package rawdb
+
+import "github.com/ethereum/go-ethereum/common"
+
+var headerBaseFeesPrefix = []byte("hb") // headerBaseFeesPrefix + hash -> RLP(types.VectorFeeBigInt)
+
+// headerBaseFeesKey = headerBaseFeesPrefix + hash
+func headerBaseFeesKey(hash common.Hash) []byte {
+	return append(headerBaseFeesPrefix, hash.Bytes()...)
+}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -115,7 +115,7 @@ type Header struct {
 	//BaseFees field is actually not part of EIP-7706 protocol, but
 	//since it requires parent to calculate, geth precalculates this field  and stores it in local blockchain
 	//this is to reduce codebase complexity as well as DB read/write operations
-	BaseFees *VectorFeeBigint `rlp:"-" json:"-"`
+	BaseFees VectorFeeBigint `rlp:"-" json:"-"`
 }
 
 // field type overrides for gencodec
@@ -595,6 +595,6 @@ func (b *Block) BaseFees() *VectorFeeBigint {
 	return &baseFees
 }
 
-func (b *Block) SetBaseFees(baseFees *VectorFeeBigint) {
+func (b *Block) SetBaseFees(baseFees VectorFeeBigint) {
 	b.header.BaseFees = baseFees
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -111,10 +111,11 @@ type Header struct {
 	GasUsedVector VectorGasLimit `json:"gasUsedVector" rlp:"optional"`
 	ExcessGas     VectorGasLimit `json:"excessGas" rlp:"optional"`
 
-	//NOTE: [rollup-geth] per EIP-7706 this field is not actually part of block header
-	//Not having this field as part of header would require even bigger code refactor
-	//thus, for time being I'm leaving this here and I want to double check if BaseFees where omitted deliberately
-	BaseFees VectorFeeBigint `rlp:"-" json:"-"`
+	//[rollup-geth] EIP-7706
+	//BaseFees field is actually not part of EIP-7706 protocol, but
+	//since it requires parent to calculate, geth precalculates this field  and stores it in local blockchain
+	//this is to reduce codebase complexity as well as DB read/write operations
+	BaseFees *VectorFeeBigint `rlp:"-" json:"-"`
 }
 
 // field type overrides for gencodec
@@ -140,6 +141,8 @@ func (h *Header) Hash() common.Hash {
 
 var headerSize = common.StorageSize(reflect.TypeOf(Header{}).Size())
 
+// TODO:[rollup-geth] what about EIP-7706 specific fields
+// Additionally why weren't EIP-4844 fields added to the size calculation?
 // Size returns the approximate memory used by all internal contents. It is used
 // to approximate and limit the memory consumption of various caches.
 func (h *Header) Size() common.StorageSize {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -585,3 +585,16 @@ func HeaderParentHashFromRLP(header []byte) common.Hash {
 	}
 	return common.BytesToHash(parentHash)
 }
+
+func (b *Block) BaseFees() *VectorFeeBigint {
+	if b.header.BaseFees == nil {
+		return nil
+	}
+
+	baseFees := b.header.BaseFees.VectorCopy()
+	return &baseFees
+}
+
+func (b *Block) SetBaseFees(baseFees *VectorFeeBigint) {
+	b.header.BaseFees = baseFees
+}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -873,6 +873,9 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 	if parent == nil {
 		return api.delayPayloadImport(block), nil
 	}
+
+	//TODO: [rollup-geth] calculate BaseFees for EIP-7706 block
+
 	// We have an existing parent, do some sanity checks to avoid the beacon client
 	// triggering too early
 	var (


### PR DESCRIPTION
This is the third PR tackling #12  ([EIP-7706](https://eips.ethereum.org/EIPS/eip-7706))

This PR is all about `BaseFees` Header field. 
The fact is that per EIP-7706 the `BaseFees` are NOT part of header (per protocol).I _guess_ this protocol design was chosen  because they can always be calculated from the parent block (header). 

### Handling (non)-existence of BaseFees 

There are 2 approaches we could take here:
1. Calculate `BaseFees` "ad-hoc" - which would require access to parent "every time" we need `BaseFees` (I'll maybe experiment whit this solution in another PR, but my guess is that it would introduce even larger diff)
2. Every time new block enters the blockchain we calculate the `BaseFees` and store them as Header field
    - Blocks can enter to the blockchain either during sync with the peers 
    - When CL issues `NewPayload` api call to the EL 
    - More "esoteric" ways, eg. blocks are loaded via CLI from disk 
    
The important thing is that all of these end up calling `core/blockchain.go|insertChain`, so if we calculate the `BaseFees` at that point, _we are good_.

### Block persistence 

There is one more, important case to consider, and that is, blocks don't live in the memory all the time. So we need to take care of `BaseFees` when storing and retrieving blocks. 

My initial idea for this was: 
- Never RLP encode `BaseFees` as part of Header (as they are not the part per protocol)
- EXCEPT when storing/retrieving from the DB

Unfortunately, this was bad idea, since `geth` assumes that RLP encoded header stored in DB has the same hash value as calling `header.Hash()` (this assumption is leveraged in several places,  [and tested here](https://github.com/NethermindEth/rollup-geth/blob/5890b61f36a01691a292b479df82df3d37c74997/core/rawdb/accessors_chain_test.go#L60)).

The solution I opted for is to store `BaseFees` as separate K/V in the DB. 
When Header is stored/read/deleted from the DB so are `BaseFees`.

The obvious downside of this approach vs _"ad-hoc" calculation_ is  that we are increasing DB size. So as mentioned before, I'll probably experiment with the "ad-hoc calculation" and see if the diff is indeed that significant. 

### HeaderChain 

HeaderChain (`core/headerchian.go`) is mostly used during the initial block sync and as a caching layer. 
I don't _thin_ that calculation `BaseFees` during HeaderChain insertion is strictly necessary, but I do it Justin Case™️ (just in case)  and I'll revisit this in the future.
  


