### PR TITLE
[EIP-7706] Created new txpool for the new tx type (VectorFeeTx)

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1458,6 +1458,12 @@ func (p *BlobPool) Pending(filter txpool.PendingFilter) map[common.Address][]*tx
 	if filter.OnlyPlainTxs {
 		return nil
 	}
+
+	//[rollup-geth] EIP-7706
+	if filter.OnlyVectorFeeTxs {
+		return nil
+	}
+
 	// Track the amount of time waiting to retrieve the list of pending blob txs
 	// from the pool and the amount of time actually spent on assembling the data.
 	// The latter will be pretty much moot, but we've kept it to have symmetric

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -529,6 +529,12 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 	if filter.OnlyBlobTxs {
 		return nil
 	}
+
+	//[rollup-geth] EIP-7706
+	if filter.OnlyVectorFeeTxs {
+		return nil
+	}
+
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -83,6 +83,9 @@ type PendingFilter struct {
 
 	OnlyPlainTxs bool // Return only plain EVM transactions (peer-join announces, block space filling)
 	OnlyBlobTxs  bool // Return only blob transactions (block blob-space filling)
+
+	//[rollup-geth] EIP-7706
+	OnlyVectorFeeTxs bool //Return only multi-dim fee transactions introduced by EIP-7706
 }
 
 // SubPool represents a specialized transaction pool that lives on its own (e.g.

--- a/core/txpool/tx_vectorfee_pool.go
+++ b/core/txpool/tx_vectorfee_pool.go
@@ -198,6 +198,10 @@ func (pool *VectorFeePoolDummy) Add(txs []*types.Transaction, local bool, sync b
 // The transactions can also be pre-filtered by the dynamic fee components to
 // reduce allocations and load on downstream subsystems.
 func (pool *VectorFeePoolDummy) Pending(filter PendingFilter) map[common.Address][]*LazyTransaction {
+	if filter.OnlyBlobTxs || filter.OnlyPlainTxs {
+		return nil
+	}
+
 	pool.lock.RLock()
 	defer pool.lock.RUnlock()
 

--- a/core/txpool/tx_vectorfee_pool.go
+++ b/core/txpool/tx_vectorfee_pool.go
@@ -1,0 +1,292 @@
+//NOTE: THIS IS DUMMY POOL; It is far from prod ready!!!
+//it is intended as helper for local testing
+
+package txpool
+
+import (
+	"math/big"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
+)
+
+type VectorFeePoolDummy struct {
+	lock sync.RWMutex
+
+	reserve AddressReserver // Address reserver to ensure exclusivity across subpools
+
+	txs          map[common.Hash]*types.Transaction
+	txsByAddress map[common.Address]types.Transactions // Transactions grouped by account
+
+	chain  BlockChain   // Chain object to access the state through
+	signer types.Signer // Transaction signer to use for sender recovery
+
+	head  *types.Header  // Current head of the chain
+	state *state.StateDB // Current state at the head of the chain
+
+	discoverFeed event.Feed // Event feed to send out new tx events on pool discovery (reorg excluded)
+	insertFeed   event.Feed // Event feed to send out new tx events on pool inclusion (reorg included)
+
+}
+
+func NewVectorFeePoolDummy(chain BlockChain) *VectorFeePoolDummy {
+	return &VectorFeePoolDummy{
+		chain:        chain,
+		signer:       types.LatestSigner(chain.Config()),
+		txs:          make(map[common.Hash]*types.Transaction),
+		txsByAddress: make(map[common.Address]types.Transactions),
+	}
+}
+
+// Filter is a selector used to decide whether a transaction would be added
+// to VectorFeePool.
+func (pool *VectorFeePoolDummy) Filter(tx *types.Transaction) bool {
+	return tx.Type() == types.VectorFeeTxType
+}
+
+// Init sets the base parameters of the subpool, allowing it to load any saved
+// transactions from disk and also permitting internal maintenance routines to
+// start up.
+//
+// These should not be passed as a constructor argument - nor should the pools
+// start by themselves - in order to keep multiple subpools in lockstep with
+// one another.
+func (pool *VectorFeePoolDummy) Init(gasTip uint64, head *types.Header, reserve AddressReserver) error {
+	// Initialize the state with head block, or fallback to empty one in
+	// case the head state is not available (might occur when node is not
+	// fully synced).
+	state, err := pool.chain.StateAt(head.Root)
+	if err != nil {
+		state, err = pool.chain.StateAt(types.EmptyRootHash)
+	}
+	if err != nil {
+		return err
+	}
+	pool.head, pool.state = head, state
+
+	return nil
+}
+
+// Close terminates any background processing threads and releases any held
+// resources.
+func (pool *VectorFeePoolDummy) Close() error {
+	return nil
+}
+
+// Reset retrieves the current state of the blockchain and ensures the content
+// of the transaction pool is valid with regard to the chain state.
+// For VectorFeePool, since it is dummy pool this not even naive implementation, but stupid
+// We just go through all transactions received by the block and remove them from the pool
+func (pool *VectorFeePoolDummy) Reset(oldHead, newHead *types.Header) {
+	statedb, err := pool.chain.StateAt(newHead.Root)
+	if err != nil {
+		log.Error("Failed to reset vector fee tx pool state", "err", err)
+		return
+	}
+
+	pool.lock.Lock()
+	defer pool.lock.Unlock()
+
+	pool.head, pool.state = newHead, statedb
+
+	latestBlock := pool.chain.GetBlock(newHead.Hash(), newHead.Number.Uint64())
+	if latestBlock == nil {
+		return
+	}
+
+	for _, tx := range latestBlock.Transactions() {
+		from, err := types.Sender(pool.signer, tx)
+		if err != nil {
+			continue
+		}
+
+		delete(pool.txs, tx.Hash())
+
+		//TODO: remove all TXs which nonce is less than the latest nonce for the given address
+		// Handle deleting transactions grouped by sender
+		if txsByAddress, ok := pool.txsByAddress[from]; ok {
+			// We don't order txs by nonce so we don't care about persevering he ordering
+			for i, txFromAddress := range txsByAddress {
+				if txToDelFound := txFromAddress.Hash() == tx.Hash(); txToDelFound {
+					txsByAddress[i] = txsByAddress[len(txsByAddress)-1]
+					pool.txsByAddress[from] = txsByAddress[:len(txsByAddress)-1]
+					break
+				}
+			}
+
+			if addressHasNoTxsLeftInPool := len(pool.txsByAddress[from]) == 0; addressHasNoTxsLeftInPool {
+				delete(pool.txsByAddress, from)
+			}
+		}
+	}
+}
+
+// SetGasTip updates the minimum price required by the subpool for a new
+// transaction, and drops all transactions below this threshold.
+func (pool *VectorFeePoolDummy) SetGasTip(tip *big.Int) {}
+
+// Has returns an indicator whether subpool has a transaction cached with the
+// given hash.
+func (pool *VectorFeePoolDummy) Has(hash common.Hash) bool {
+	pool.lock.RLock()
+	defer pool.lock.RUnlock()
+
+	tx, has := pool.txs[hash]
+	return has && tx != nil
+}
+
+// Get returns a transaction if it is contained in the pool, or nil otherwise.
+func (pool *VectorFeePoolDummy) Get(hash common.Hash) *types.Transaction {
+	pool.lock.RLock()
+	defer pool.lock.RUnlock()
+
+	tx := pool.txs[hash]
+	return tx
+}
+
+// Add enqueues a batch of transactions into the pool if they are valid. Due
+// to the large transaction churn, add may postpone fully integrating the tx
+// to a later point to batch multiple ones together.
+func (pool *VectorFeePoolDummy) Add(txs []*types.Transaction, local bool, sync bool) []error {
+	if len(txs) == 0 {
+		return nil
+	}
+
+	//TODO: validate tx
+	pool.lock.Lock()
+	defer pool.lock.Unlock()
+
+	var errors []error
+	adds := make(types.Transactions, 0, len(txs))
+
+	for _, tx := range txs {
+		h := tx.Hash()
+		if _, alreadyInThePool := pool.txs[h]; alreadyInThePool {
+			continue
+		}
+
+		from, err := types.Sender(pool.signer, tx)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+
+		pool.txs[tx.Hash()] = tx
+		pool.txsByAddress[from] = append(pool.txsByAddress[from], tx)
+
+		adds = append(adds, tx)
+	}
+
+	if len(adds) > 0 {
+		pool.insertFeed.Send(core.NewTxsEvent{Txs: adds})
+		pool.discoverFeed.Send(core.NewTxsEvent{Txs: adds})
+	}
+
+	return errors
+}
+
+// Pending retrieves all currently processable transactions, grouped by origin
+// account and sorted by nonce.
+//
+// The transactions can also be pre-filtered by the dynamic fee components to
+// reduce allocations and load on downstream subsystems.
+func (pool *VectorFeePoolDummy) Pending(filter PendingFilter) map[common.Address][]*LazyTransaction {
+	pool.lock.RLock()
+	defer pool.lock.RUnlock()
+
+	execStart := time.Now()
+	result := make(map[common.Address][]*LazyTransaction, len(pool.txsByAddress))
+
+	for address, txs := range pool.txsByAddress {
+		lazyTxs := make([]*LazyTransaction, len(txs))
+
+		for i, tx := range txs {
+			lazyTx := &LazyTransaction{
+				Pool:      pool,
+				Hash:      tx.Hash(),
+				Time:      execStart,
+				GasFeeCap: uint256.MustFromBig(tx.GasFeeCap()),
+				GasTipCap: uint256.MustFromBig(tx.GasTipCap()),
+				Gas:       tx.Gas(),
+				BlobGas:   tx.BlobGas(),
+			}
+
+			lazyTxs[i] = lazyTx
+		}
+
+		result[address] = lazyTxs
+	}
+
+	return result
+}
+
+// SubscribeTransactions subscribes to new transaction events. The subscriber
+// can decide whether to receive notifications only for newly seen transactions
+// or also for reorged out ones.
+func (pool *VectorFeePoolDummy) SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool) event.Subscription {
+	if reorgs {
+		return pool.insertFeed.Subscribe(ch)
+	} else {
+		return pool.discoverFeed.Subscribe(ch)
+	}
+}
+
+// Nonce returns the next nonce of an account, with all transactions executable
+// by the pool already applied on top.
+func (pool *VectorFeePoolDummy) Nonce(addr common.Address) uint64 {
+	pool.lock.RLock()
+	defer pool.lock.RUnlock()
+
+	if txs, ok := pool.txsByAddress[addr]; ok && len(txs) > 0 {
+		// this is needed because txs are not ordered by nonce
+		maxNonce := txs[0].Nonce()
+		for _, tx := range txs {
+			if tx.Nonce() > maxNonce {
+				maxNonce = tx.Nonce()
+			}
+		}
+
+		return maxNonce + 1
+	}
+
+	return pool.state.GetNonce(addr)
+}
+
+// Stats retrieves the current pool stats, namely the number of pending and the
+// number of queued (non-executable) transactions.
+func (pool *VectorFeePoolDummy) Stats() (int, int) {
+	return 0, 0
+}
+
+// Content retrieves the data content of the transaction pool, returning all the
+// pending as well as queued transactions, grouped by account and sorted by nonce.
+func (pool *VectorFeePoolDummy) Content() (map[common.Address][]*types.Transaction, map[common.Address][]*types.Transaction) {
+	return make(map[common.Address][]*types.Transaction), make(map[common.Address][]*types.Transaction)
+}
+
+// ContentFrom retrieves the data content of the transaction pool, returning the
+// pending as well as queued transactions of this address, grouped by nonce.
+func (pool *VectorFeePoolDummy) ContentFrom(addr common.Address) ([]*types.Transaction, []*types.Transaction) {
+	return []*types.Transaction{}, []*types.Transaction{}
+}
+
+// Locals retrieves the accounts currently considered local by the pool.
+func (pool *VectorFeePoolDummy) Locals() []common.Address {
+	return []common.Address{}
+}
+
+// Status returns the known status (unknown/pending/queued) of a transaction
+// identified by their hashes.
+func (pool *VectorFeePoolDummy) Status(hash common.Hash) TxStatus {
+	if pool.Has(hash) {
+		return TxStatusPending
+	}
+	return TxStatusUnknown
+}

--- a/core/txpool/tx_vectorfee_pool_test.go
+++ b/core/txpool/tx_vectorfee_pool_test.go
@@ -1,0 +1,282 @@
+package txpool
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/triedb"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVectorFeePool_Add(t *testing.T) {
+	_, pool, key, addr := setupTestPool(t)
+	defer pool.Close()
+
+	recipient := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	tests := []struct {
+		name string
+		tx   *types.Transaction
+	}{
+		{
+			name: "valid transaction",
+			tx: createSignedVectorFeeTx(t, 0, recipient, big.NewInt(1),
+				21000, key),
+		},
+		{
+			name: "duplicate transaction",
+			tx: createSignedVectorFeeTx(t, 0, recipient, big.NewInt(1),
+				21000, key),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := pool.Add([]*types.Transaction{tt.tx}, false, false)
+			assert.Len(t, errs, 0)
+			assert.Len(t, pool.txs, 1)
+			assert.Len(t, pool.txsByAddress, 1)
+			assert.Len(t, pool.txsByAddress[addr], 1)
+
+			assert.True(t, pool.Has(tt.tx.Hash()))
+		})
+	}
+}
+
+func TestVectorFeePool_Pending(t *testing.T) {
+	_, pool, key, addr := setupTestPool(t)
+	defer pool.Close()
+
+	recipient := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	// Add multiple transactions
+	txs := []*types.Transaction{
+		createSignedVectorFeeTx(t, 0, recipient, big.NewInt(1), 21000, key),
+		createSignedVectorFeeTx(t, 1, recipient, big.NewInt(1), 21000, key),
+		createSignedVectorFeeTx(t, 2, recipient, big.NewInt(1), 21000, key),
+
+		// duplicate should not be added
+		createSignedVectorFeeTx(t, 0, recipient, big.NewInt(1), 21000, key),
+	}
+
+	errs := pool.Add(txs, false, false)
+	assert.Empty(t, errs)
+
+	pending := pool.Pending(PendingFilter{})
+	assert.Len(t, pending[addr], 3)
+}
+
+func TestVectorFeePool_Reset(t *testing.T) {
+	blockchain, pool, key, _ := setupTestPool(t)
+	defer pool.Close()
+
+	recipient := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	// Add a transaction
+	tx := createSignedVectorFeeTx(t, 0, recipient, big.NewInt(1), 21000, key)
+	errs := pool.Add([]*types.Transaction{tx}, false, false)
+	assert.Empty(t, errs)
+
+	// Verify it's in the pool
+	assert.True(t, pool.Has(tx.Hash()))
+
+	// Create a new block that doesn't include our TX
+	newHeader := &types.Header{
+		Number:     big.NewInt(1),
+		GasLimit:   8000000,
+		ParentHash: pool.head.Hash(),
+	}
+
+	pool.Reset(pool.head, newHeader)
+	// We didn't receive block with this transaction yet, so it should still be in the pool
+	assert.True(t, pool.Has(tx.Hash()))
+
+	// Create a new block that includes our TX
+	newHeader = &types.Header{
+		Number:     big.NewInt(2),
+		GasLimit:   8000000,
+		ParentHash: pool.head.Hash(),
+	}
+
+	newBlock := types.NewBlockWithHeader(newHeader).WithBody(types.Body{
+		Transactions: types.Transactions{tx},
+	})
+	blockchain.blocks[newHeader.Number.Uint64()] = newBlock
+
+	pool.Reset(pool.head, newHeader)
+
+	// Pool should be empty
+	assert.False(t, pool.Has(tx.Hash()))
+	assert.Len(t, pool.txs, 0)
+	assert.Len(t, pool.txsByAddress, 0)
+}
+
+func TestVectorFeePool_Get(t *testing.T) {
+	_, pool, key, _ := setupTestPool(t)
+	defer pool.Close()
+
+	recipient := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	// Add a transaction
+	tx := createSignedVectorFeeTx(t, 0, recipient, big.NewInt(1000), 21000, key)
+	errs := pool.Add([]*types.Transaction{tx}, false, false)
+	assert.Empty(t, errs)
+
+	// Test Get
+	retrieved := pool.Get(tx.Hash())
+	assert.NotNil(t, retrieved)
+	assert.Equal(t, tx.Hash(), retrieved.Hash())
+
+	// Test Get with non-existent transaction
+	retrieved = pool.Get(common.Hash{})
+	assert.Nil(t, retrieved)
+}
+
+func TestVectorFeePool_Nonce(t *testing.T) {
+	_, pool, key, addr := setupTestPool(t)
+	defer pool.Close()
+
+	recipient := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	// Check initial nonce
+	assert.Equal(t, uint64(0), pool.Nonce(addr))
+
+	// Add transactions with different nonces
+	txs := []*types.Transaction{
+		createSignedVectorFeeTx(t, 0, recipient, big.NewInt(1000), 21000, key),
+		createSignedVectorFeeTx(t, 1, recipient, big.NewInt(1000), 21000, key),
+		createSignedVectorFeeTx(t, 2, recipient, big.NewInt(1000), 21000, key),
+	}
+
+	errs := pool.Add(txs, false, false)
+	assert.Empty(t, errs)
+
+	// Check nonce after adding transactions
+	assert.Equal(t, uint64(3), pool.Nonce(addr))
+}
+
+func TestVectorFeePool_Filter(t *testing.T) {
+	_, pool, key, _ := setupTestPool(t)
+	defer pool.Close()
+
+	recipient := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	// Create different types of transactions
+	vectorFeeTx := createSignedVectorFeeTx(t, 0, recipient, big.NewInt(1000), 21000, key)
+	legacyTx := types.NewTransaction(0, recipient, big.NewInt(1000), 21000, big.NewInt(1), nil)
+
+	// Test filter
+	assert.True(t, pool.Filter(vectorFeeTx))
+	assert.False(t, pool.Filter(legacyTx))
+}
+
+type testBlockChain struct {
+	statedb       *state.StateDB
+	config        *params.ChainConfig
+	gasLimit      uint64
+	chainHeadFeed *event.Feed
+
+	blocks map[uint64]*types.Block
+}
+
+func (bc *testBlockChain) CurrentBlock() *types.Header {
+	return &types.Header{
+		Number:   new(big.Int),
+		GasLimit: bc.gasLimit,
+	}
+}
+
+func (bc *testBlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
+	return bc.statedb, nil
+}
+
+func (bc *testBlockChain) Config() *params.ChainConfig {
+	return bc.config
+}
+
+func (bc *testBlockChain) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {
+	return bc.chainHeadFeed.Subscribe(ch)
+}
+
+func (bc *testBlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {
+	block := bc.blocks[number]
+	return block
+}
+
+func setupTestPool(t *testing.T) (*testBlockChain, *VectorFeePoolDummy, *ecdsa.PrivateKey, common.Address) {
+	var (
+		db  = rawdb.NewMemoryDatabase()
+		tdb = triedb.NewDatabase(db, nil)
+		sdb = state.NewDatabase(tdb, nil)
+	)
+	statedb, _ := state.New(types.EmptyRootHash, sdb)
+
+	blockchain := &testBlockChain{
+		statedb:  statedb,
+		config:   getBlockChianConfig(),
+		gasLimit: 8000000,
+		blocks:   make(map[uint64]*types.Block),
+	}
+
+	pool := NewVectorFeePoolDummy(blockchain)
+
+	// Create a funded account
+	key, addr := generateAccount()
+	statedb.AddBalance(addr, uint256.NewInt(1000000000000000000), tracing.BalanceChangeUnspecified) // 1 ETH
+
+	err := pool.Init(1, blockchain.CurrentBlock(), func(addr common.Address, reserve bool) error {
+		return nil
+	})
+	assert.NoError(t, err)
+
+	return blockchain, pool, key, addr
+}
+
+func generateAccount() (*ecdsa.PrivateKey, common.Address) {
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	return key, addr
+}
+
+func createSignedVectorFeeTx(t *testing.T, nonce uint64, to common.Address, amount *big.Int, gasLimit uint64, key *ecdsa.PrivateKey) *types.Transaction {
+	tx := types.NewTx(&types.VectorFeeTx{
+		ChainID:    uint256.NewInt(1),
+		Nonce:      nonce,
+		Gas:        gasLimit,
+		GasTipCaps: types.VectorFeeUint{uint256.NewInt(1), uint256.NewInt(3), uint256.NewInt(3)},
+		GasFeeCaps: types.VectorFeeUint{uint256.NewInt(4), uint256.NewInt(5), uint256.NewInt(6)},
+		To:         to,
+		Value:      uint256.MustFromBig(amount),
+		Data:       nil,
+	})
+
+	signedTx, err := types.SignTx(tx, types.LatestSigner(getBlockChianConfig()), key)
+	if err != nil {
+		t.Errorf("Could not sign tx: %v", err)
+		t.FailNow()
+	}
+
+	return signedTx
+}
+
+func getBlockChianConfig() *params.ChainConfig {
+	EIP7706Time := uint64(0)
+	var blockChainConfig params.ChainConfig = params.ChainConfig{
+		ChainID:     big.NewInt(1),
+		Ethash:      new(params.EthashConfig),
+		EIP7706Time: &EIP7706Time,
+	}
+
+	return &blockChainConfig
+}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -24,10 +24,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // TxStatus is the current status of a transaction as seen by the pool.
@@ -57,6 +59,18 @@ type BlockChain interface {
 
 	// SubscribeChainHeadEvent subscribes to new blocks being added to the chain.
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
+
+	// StateAt returns a state database for a given root hash (generally the head).
+	// [rollup-geth] EIP-7706
+	StateAt(root common.Hash) (*state.StateDB, error)
+
+	// Config retrieves the chain's fork configuration.
+	// [rollup-geth] EIP-7706
+	Config() *params.ChainConfig
+
+	// GetBlock retrieves a specific block, used during pool resets.
+	// [rollup-geth] EIP-7706
+	GetBlock(hash common.Hash, number uint64) *types.Block
 }
 
 // TxPool is an aggregator for various transaction specific pools, collectively

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -299,13 +299,34 @@ func (tx *Transaction) AccessList() AccessList { return tx.inner.accessList() }
 func (tx *Transaction) Gas() uint64 { return tx.inner.gas() }
 
 // GasPrice returns the gas price of the transaction.
-func (tx *Transaction) GasPrice() *big.Int { return new(big.Int).Set(tx.inner.gasPrice()) }
+func (tx *Transaction) GasPrice() *big.Int {
+	// Modified by [rollup-geth] EIP-7706 tx_vector_fee returns nil for gasPrice()
+	// So we need to take care of this edge-case
+	if gasPrice := tx.inner.gasPrice(); gasPrice != nil {
+		return new(big.Int).Set(tx.inner.gasPrice())
+	}
+	return nil
+}
 
 // GasTipCap returns the gasTipCap per gas of the transaction.
-func (tx *Transaction) GasTipCap() *big.Int { return new(big.Int).Set(tx.inner.gasTipCap()) }
+func (tx *Transaction) GasTipCap() *big.Int {
+	// Modified by [rollup-geth] EIP-7706 tx_vector_fee returns nil for gasTipCap()
+	// So we need to take care of this edge-case
+	if gasTipCap := tx.inner.gasTipCap(); gasTipCap != nil {
+		return new(big.Int).Set(tx.inner.gasTipCap())
+	}
+	return nil
+}
 
 // GasFeeCap returns the fee cap per gas of the transaction.
-func (tx *Transaction) GasFeeCap() *big.Int { return new(big.Int).Set(tx.inner.gasFeeCap()) }
+func (tx *Transaction) GasFeeCap() *big.Int {
+	// Modified by [rollup-geth] EIP-7706 tx_vector_fee returns nil for gasFeeCap()
+	// So we need to take care of this edge-case
+	if gasFeeCap := tx.inner.gasFeeCap(); gasFeeCap != nil {
+		return new(big.Int).Set(tx.inner.gasFeeCap())
+	}
+	return nil
+}
 
 // Value returns the ether amount of the transaction.
 func (tx *Transaction) Value() *big.Int { return new(big.Int).Set(tx.inner.value()) }
@@ -393,6 +414,8 @@ func (tx *Transaction) EffectiveGasTipIntCmp(other *big.Int, baseFee *big.Int) i
 	}
 	return tx.EffectiveGasTipValue(baseFee).Cmp(other)
 }
+
+//TODO: [rollup-geth] VectorFee transactions can also contain blobs
 
 // BlobGas returns the blob gas limit of the transaction for blob transactions, 0 otherwise.
 func (tx *Transaction) BlobGas() uint64 {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -67,6 +67,9 @@ func LatestSigner(config *params.ChainConfig) Signer {
 	var signer Signer
 	if config.ChainID != nil {
 		switch {
+		//[rollup-geth] EIP-7706
+		case config.EIP7706Time != nil:
+			signer = NewEIP7706Signer(config.ChainID)
 		case config.CancunTime != nil:
 			signer = NewCancunSigner(config.ChainID)
 		case config.LondonBlock != nil:

--- a/core/types/transaction_signing_rollup.go
+++ b/core/types/transaction_signing_rollup.go
@@ -1,0 +1,91 @@
+package types
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type eip7706Signer struct{ cancunSigner }
+
+// NewCancunSigner returns a signer that accepts
+// - EIP-77706 vector fee transactions
+// - EIP-4844 blob transactions
+// - EIP-1559 dynamic fee transactions
+// - EIP-2930 access list transactions,
+// - EIP-155 replay protected transactions, and
+// - legacy Homestead transactions.
+func NewEIP7706Signer(chainId *big.Int) Signer {
+	return eip7706Signer{cancunSigner{londonSigner{eip2930Signer{NewEIP155Signer(chainId)}}}}
+}
+
+// Sender returns the sender address of the transaction.
+func (s eip7706Signer) Sender(tx *Transaction) (common.Address, error) {
+	if tx.Type() != VectorFeeTxType {
+		return s.cancunSigner.Sender(tx)
+	}
+
+	V, R, S := tx.RawSignatureValues()
+	// Blob txs are defined to use 0 and 1 as their recovery
+	// id, add 27 to become equivalent to unprotected Homestead signatures.
+	V = new(big.Int).Add(V, big.NewInt(27))
+	if tx.ChainId().Cmp(s.chainId) != 0 {
+		return common.Address{}, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, tx.ChainId(), s.chainId)
+	}
+	return recoverPlain(s.Hash(tx), R, S, V, true)
+}
+
+// SignatureValues returns the raw R, S, V values corresponding to the
+// given signature.
+func (signer eip7706Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
+	txData, ok := tx.inner.(*VectorFeeTx)
+	if !ok {
+		return signer.cancunSigner.SignatureValues(tx, sig)
+	}
+	// Check that chain ID of tx matches the signer. We also accept ID zero here,
+	// because it indicates that the chain ID was not specified in the tx.
+	if txData.ChainID.Sign() != 0 && txData.ChainID.ToBig().Cmp(signer.chainId) != 0 {
+		return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, txData.ChainID, signer.chainId)
+	}
+
+	R, S, _ = decodeSignature(sig)
+	V = big.NewInt(int64(sig[64]))
+	return R, S, V, nil
+}
+
+// Returns chain id used by signer
+func (s eip7706Signer) ChainID() *big.Int {
+	return s.chainId
+}
+
+// TODO: [rollup-geth] Question: I guess all clients must agree to follow this exact structure otherwise signatures will be off?
+
+// Hash returns 'signature hash', i.e. the transaction hash that is signed by the
+// private key. This hash does not uniquely identify the transaction.
+func (s eip7706Signer) Hash(tx *Transaction) common.Hash {
+	if tx.Type() != VectorFeeTxType {
+		return s.cancunSigner.Hash(tx)
+	}
+	return prefixedRlpHash(
+		tx.Type(),
+		[]interface{}{
+			s.chainId,
+			tx.Nonce(),
+			tx.GasTipCaps(),
+			tx.GasFeeCaps(),
+			tx.Gas(),
+			tx.To(),
+			tx.Value(),
+			tx.Data(),
+			tx.AccessList(),
+			tx.BlobGasFeeCap(),
+			tx.BlobHashes(),
+		})
+}
+
+// Equal returns true if the given signer is the same as the receiver.
+func (s eip7706Signer) Equal(s2 Signer) bool {
+	x, ok := s2.(eip7706Signer)
+	return ok && x.chainId.Cmp(s.chainId) == 0
+}

--- a/core/types/tx_vector_fee.go
+++ b/core/types/tx_vector_fee.go
@@ -35,7 +35,7 @@ type VectorFeeTx struct {
 }
 
 // accessors for innerTx. (satisfies TxData Interface)
-func (tx *VectorFeeTx) txType() byte           { return DynamicFeeTxType }
+func (tx *VectorFeeTx) txType() byte           { return VectorFeeTxType }
 func (tx *VectorFeeTx) chainID() *big.Int      { return tx.ChainID.ToBig() }
 func (tx *VectorFeeTx) accessList() AccessList { return tx.AccessList }
 func (tx *VectorFeeTx) data() []byte           { return tx.Data }
@@ -133,11 +133,11 @@ func (tx *VectorFeeTx) copy() TxData {
 	}
 
 	for i, v := range tx.GasTipCaps {
-		cpy.GasTipCaps[i].Set(v)
+		cpy.GasTipCaps[i] = new(uint256.Int).Set(v)
 	}
 
 	for i, v := range tx.GasFeeCaps {
-		cpy.GasFeeCaps[i].Set(v)
+		cpy.GasFeeCaps[i] = new(uint256.Int).Set(v)
 	}
 
 	if tx.V != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -231,7 +231,11 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	legacyPool := legacypool.New(config.TxPool, eth.blockchain)
 
-	eth.txPool, err = txpool.New(config.TxPool.PriceLimit, eth.blockchain, []txpool.SubPool{legacyPool, blobPool})
+	//[rollup-geth] EIP-7706
+	vectorFeeTxPool := txpool.NewVectorFeePoolDummy(eth.blockchain)
+	txPools := []txpool.SubPool{legacyPool, blobPool, vectorFeeTxPool}
+
+	eth.txPool, err = txpool.New(config.TxPool.PriceLimit, eth.blockchain, txPools)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is the fourth PR tackling #12  ([EIP-7706](https://eips.ethereum.org/EIPS/eip-7706))

This PR is all about newly crated `tx_vector_fee_pool` for new transaction type specified by EIP-7706 (`tx_vector_fee`).

**IMPORTANT**
This is "dummy pool" in a sense that it's very rudimentary and poorly designed, and it  doesn't even fully implement all the necessary `subpool` interface methods. 

That being said, it's useful for the time being to manually test if the EIP-7706 changes work as inteded.
By manually I mean:
1. Create `VectorFeeTx` 
2. Send it to `geht` node via `eth_sendRawTransaction`
3. Transaction should be included in the pool
4. Transaction should be included in the next block by `miner` (this will be implemented in the next PR)
5. Miner should be able to produce valid block
6. Upon receiving the block produced by miner in (5) EL should be able to successfully validate and insert block into the blockchain
