### PR TITLE
[EIP-7706] Miner updates to include VectorFeeTx in block

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -80,9 +80,9 @@ type ExecutableData struct {
 	ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
 
 	//[rollup-geth] Add EIP-7706 specific fields
-	GasLimits     types.VectorGasLimit `json:"gasLimits"`
-	GasUsedVector types.VectorGasLimit `json:"gasUsedVector"`
-	ExcessGas     types.VectorGasLimit `json:"excessGas"`
+	GasLimits     types.VectorGasLimit `json:"gasLimits,omitempty"`
+	GasUsedVector types.VectorGasLimit `json:"gasUsedVector,omitempty"`
+	ExcessGas     types.VectorGasLimit `json:"excessGas,omitempty"`
 }
 
 // JSON type overrides for executableData.
@@ -308,7 +308,6 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 		nil
 }
 
-// TODO: [rollup-geth] Add EIP-7706 fields
 // BlockToExecutableData constructs the ExecutableData structure by filling the
 // fields from the given block. It assumes the given block is post-merge block.
 func BlockToExecutableData(block *types.Block, fees *big.Int, sidecars []*types.BlobTxSidecar) *ExecutionPayloadEnvelope {

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -79,7 +79,10 @@ type ExecutableData struct {
 	Deposits         types.Deposits          `json:"depositRequests"`
 	ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
 
-	//TODO:: [rollup-geth] Add EIP-7706 specific fields
+	//[rollup-geth] Add EIP-7706 specific fields
+	GasLimits     types.VectorGasLimit `json:"gasLimits"`
+	GasUsedVector types.VectorGasLimit `json:"gasUsedVector"`
+	ExcessGas     types.VectorGasLimit `json:"excessGas"`
 }
 
 // JSON type overrides for executableData.
@@ -221,7 +224,6 @@ func ExecutableDataToBlock(data ExecutableData, versionedHashes []common.Hash, b
 	return block, nil
 }
 
-// TODO: [rollup-geth] Add EIP-7706 fields
 // ExecutableDataToBlockNoHash is analogous to ExecutableDataToBlock, but is used
 // for stateless execution, so it skips checking if the executable data hashes to
 // the requested hash (stateless has to *compute* the root hash, it's not given).
@@ -294,6 +296,11 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 		BlobGasUsed:      data.BlobGasUsed,
 		ParentBeaconRoot: beaconRoot,
 		RequestsHash:     requestsHash,
+
+		//[rollup-geth] EIP-7706 fields
+		GasLimits:     data.GasLimits,
+		GasUsedVector: data.GasUsedVector,
+		ExcessGas:     data.ExcessGas,
 	}
 	return types.NewBlockWithHeader(header).
 			WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals, Requests: requests}).
@@ -324,6 +331,11 @@ func BlockToExecutableData(block *types.Block, fees *big.Int, sidecars []*types.
 		BlobGasUsed:      block.BlobGasUsed(),
 		ExcessBlobGas:    block.ExcessBlobGas(),
 		ExecutionWitness: block.ExecutionWitness(),
+
+		//[rollup-geth] EIP-7706 fields
+		GasLimits:     block.Header().GasLimits,
+		GasUsedVector: block.Header().GasUsedVector,
+		ExcessGas:     block.Header().ExcessGas,
 	}
 	bundle := BlobsBundleV1{
 		Commitments: make([]hexutil.Bytes, 0),

--- a/consensus/misc/eip7706/eip7706.go
+++ b/consensus/misc/eip7706/eip7706.go
@@ -97,15 +97,8 @@ func CalcBaseFeesFromParentHeader(config *params.ChainConfig, parent *types.Head
 		return nil, errors.New("parent header is nil")
 	}
 
-	if !config.IsEIP7706(parent.Number, parent.Time) {
-		return nil, errors.New("Parent is not an EIP-7706 block")
-	}
-
-	if err := MakeSureEIP7706FieldsAreNonNil(parent); err != nil {
-		return nil, err
-	}
-
-	return CalcBaseFees(parent.ExcessGas, parent.GasLimits), nil
+	_, excessGas, gasLimits := SanitizeEIP7706Fields(parent)
+	return CalcBaseFees(excessGas, gasLimits), nil
 }
 
 // CalcBaseFees  calculates vector of the base fees for current block header given parent excess gas and targets

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -222,19 +222,13 @@ func (hc *HeaderChain) WriteHeaders(headers []*types.Header) (int, error) {
 		newTD.Add(newTD, header.Difficulty)
 
 		//[rollup-geth] EIP-7706
-		if header.BaseFees == nil {
-			var parent *types.Header
-			if i > 0 {
-				parent = headers[i-1]
-			} else {
-				parent = hc.GetHeader(header.ParentHash, header.Number.Uint64()-1)
-			}
-
-			baseFees, err := eip7706.CalcBaseFeesFromParentHeader(hc.config, parent)
-			if err == nil {
-				header.BaseFees = baseFees
-			}
+		var parent *types.Header
+		if i > 0 {
+			parent = headers[i-1]
+		} else {
+			parent = hc.GetHeader(header.ParentHash, header.Number.Uint64()-1)
 		}
+		setBaseFeesForHeader(header, parent, hc.config)
 
 		// If the parent was not present, store it
 		// If the header is already known, skip it, otherwise store
@@ -666,4 +660,19 @@ func (hc *HeaderChain) Engine() consensus.Engine { return hc.engine }
 // a header chain does not have blocks available for retrieval.
 func (hc *HeaderChain) GetBlock(hash common.Hash, number uint64) *types.Block {
 	return nil
+}
+
+// [rollup-geth] EIP-7706
+func setBaseFeesForHeader(header *types.Header, parent *types.Header, config *params.ChainConfig) {
+	if baseFeesAlreadySet := header.BaseFees != nil; baseFeesAlreadySet {
+		return
+	}
+	if notEIP7706Block := !config.IsEIP7706(header.Number, header.Time); notEIP7706Block {
+		return
+	}
+
+	baseFees, err := eip7706.CalcBaseFeesFromParentHeader(config, parent)
+	if err == nil {
+		header.BaseFees = baseFees
+	}
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -82,7 +82,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		ProcessParentBlockHash(block.ParentHash(), vmenv, statedb)
 	}
 
-	//[rollup-geth] EIP-7706
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
 		msg, err := TransactionToMessage(tx, signer, header, p.config)
@@ -187,6 +186,10 @@ func MakeReceipt(evm *vm.EVM, result *ExecutionResult, statedb *state.StateDB, b
 	receipt.BlockHash = blockHash
 	receipt.BlockNumber = blockNumber
 	receipt.TransactionIndex = uint(statedb.TxIndex())
+
+	//[rollup-geth] EIP-7706
+	receipt.GasUsedVector = result.UsedGasVector
+
 	return receipt
 }
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -37,6 +37,9 @@ type ExecutionResult struct {
 	RefundedGas uint64 // Total gas refunded after execution
 	Err         error  // Any error encountered during the execution(listed in core/vm/errors.go)
 	ReturnData  []byte // Returned data from evm(function result or data supplied with revert opcode)
+
+	//[rollup-geth] EIP-7706
+	UsedGasVector types.VectorGasLimit
 }
 
 // Unwrap returns the internal evm error which allows us for further
@@ -406,6 +409,9 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		RefundedGas: gasRefund,
 		Err:         vmerr,
 		ReturnData:  ret,
+
+		//[rollup-geth] EIP-7706
+		UsedGasVector: st.vectorGasUsed(),
 	}, nil
 }
 

--- a/core/state_transition_rollup.go
+++ b/core/state_transition_rollup.go
@@ -359,6 +359,16 @@ func (st *StateTransition) vectorGasUsed() types.VectorGasLimit {
 	// NOTE: Gas used by [execution, blob, calldata]
 	// Blob and calldata gas used is actually same as their gas limits (because it is precomputed from tx data and known upfront)
 	// Only execution gas is not known upfront and has to be determined while executing the transaction
+
+	// If message was not created using TransactionToMessage() call this can be nil
+	if st.msg.GasLimits == nil {
+		return nil
+	}
+
+	if !st.evm.ChainConfig().IsEIP7706(st.evm.Context.BlockNumber, st.evm.Context.Time) {
+		return nil
+	}
+
 	gasUsed := st.msg.GasLimits
 	gasUsed[types.ExecutionGasIndex] = st.gasUsed()
 

--- a/core/txpool/tx_vectorfee_pool.go
+++ b/core/txpool/tx_vectorfee_pool.go
@@ -163,10 +163,10 @@ func (pool *VectorFeePoolDummy) Add(txs []*types.Transaction, local bool, sync b
 	pool.lock.Lock()
 	defer pool.lock.Unlock()
 
-	var errors []error
+	errors := make([]error, len(txs))
 	adds := make(types.Transactions, 0, len(txs))
 
-	for _, tx := range txs {
+	for i, tx := range txs {
 		h := tx.Hash()
 		if _, alreadyInThePool := pool.txs[h]; alreadyInThePool {
 			continue
@@ -174,7 +174,7 @@ func (pool *VectorFeePoolDummy) Add(txs []*types.Transaction, local bool, sync b
 
 		from, err := types.Sender(pool.signer, tx)
 		if err != nil {
-			errors = append(errors, err)
+			errors[i] = err
 			continue
 		}
 
@@ -182,6 +182,7 @@ func (pool *VectorFeePoolDummy) Add(txs []*types.Transaction, local bool, sync b
 		pool.txsByAddress[from] = append(pool.txsByAddress[from], tx)
 
 		adds = append(adds, tx)
+		log.Trace("Pooled new future transaction", "hash", tx.Hash(), "from", from, "to", tx.To())
 	}
 
 	if len(adds) > 0 {

--- a/core/txpool/tx_vectorfee_pool_test.go
+++ b/core/txpool/tx_vectorfee_pool_test.go
@@ -44,7 +44,7 @@ func TestVectorFeePool_Add(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			errs := pool.Add([]*types.Transaction{tt.tx}, false, false)
-			assert.Len(t, errs, 0)
+			allErrorsNil(t, errs)
 			assert.Len(t, pool.txs, 1)
 			assert.Len(t, pool.txsByAddress, 1)
 			assert.Len(t, pool.txsByAddress[addr], 1)
@@ -71,7 +71,7 @@ func TestVectorFeePool_Pending(t *testing.T) {
 	}
 
 	errs := pool.Add(txs, false, false)
-	assert.Empty(t, errs)
+	allErrorsNil(t, errs)
 
 	pending := pool.Pending(PendingFilter{})
 	assert.Len(t, pending[addr], 3)
@@ -86,7 +86,7 @@ func TestVectorFeePool_Reset(t *testing.T) {
 	// Add a transaction
 	tx := createSignedVectorFeeTx(t, 0, recipient, big.NewInt(1), 21000, key)
 	errs := pool.Add([]*types.Transaction{tx}, false, false)
-	assert.Empty(t, errs)
+	allErrorsNil(t, errs)
 
 	// Verify it's in the pool
 	assert.True(t, pool.Has(tx.Hash()))
@@ -131,7 +131,7 @@ func TestVectorFeePool_Get(t *testing.T) {
 	// Add a transaction
 	tx := createSignedVectorFeeTx(t, 0, recipient, big.NewInt(1000), 21000, key)
 	errs := pool.Add([]*types.Transaction{tx}, false, false)
-	assert.Empty(t, errs)
+	allErrorsNil(t, errs)
 
 	// Test Get
 	retrieved := pool.Get(tx.Hash())
@@ -160,7 +160,7 @@ func TestVectorFeePool_Nonce(t *testing.T) {
 	}
 
 	errs := pool.Add(txs, false, false)
-	assert.Empty(t, errs)
+	allErrorsNil(t, errs)
 
 	// Check nonce after adding transactions
 	assert.Equal(t, uint64(3), pool.Nonce(addr))
@@ -279,4 +279,10 @@ func getBlockChianConfig() *params.ChainConfig {
 	}
 
 	return &blockChainConfig
+}
+
+func allErrorsNil(t *testing.T, errs []error) {
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -71,6 +71,9 @@ type Receipt struct {
 	BlockHash        common.Hash `json:"blockHash,omitempty"`
 	BlockNumber      *big.Int    `json:"blockNumber,omitempty"`
 	TransactionIndex uint        `json:"transactionIndex"`
+
+	//[rollup-geth] EIP-7706
+	GasUsedVector VectorGasLimit
 }
 
 type receiptMarshaling struct {

--- a/core/types/transaction_rollup.go
+++ b/core/types/transaction_rollup.go
@@ -22,9 +22,9 @@ func (tx *Transaction) EffectiveGasTips(baseFees VectorFeeBigint) VectorFeeBigin
 	effectiveTips := make(VectorFeeBigint, VectorFeeTypesCount)
 	for i, baseFee := range baseFees {
 		if baseFee == nil {
-			effectiveTips[i].Set(gasTipCaps[i])
+			effectiveTips[i] = new(big.Int).Set(gasTipCaps[i])
 		} else {
-			effectiveTips[i] = math.BigMin(gasTipCaps[i], effectiveTips[i].Sub(gasFeeCaps[i], baseFee))
+			effectiveTips[i] = math.BigMin(gasTipCaps[i], new(big.Int).Sub(gasFeeCaps[i], baseFee))
 		}
 	}
 
@@ -39,9 +39,9 @@ func (tx *Transaction) EffectiveGasPrices(baseFees VectorFeeBigint) VectorFeeBig
 
 	for i, baseFee := range baseFees {
 		if baseFee == nil {
-			effectiveFees[i].Set(gasFeeCaps[i])
+			effectiveFees[i] = new(big.Int).Set(gasFeeCaps[i])
 		} else {
-			effectiveFees[i] = math.BigMin(effectiveFees[i].Add(gasTipCaps[i], baseFee), gasFeeCaps[i])
+			effectiveFees[i] = math.BigMin(new(big.Int).Add(gasTipCaps[i], baseFee), gasFeeCaps[i])
 		}
 	}
 

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,6 +40,9 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64) Signer {
 	var signer Signer
 	switch {
+	//[rollup-geth] EIP-7706
+	case config.EIP7706Time != nil:
+		signer = NewEIP7706Signer(config.ChainID)
 	case config.IsCancun(blockNumber, blockTime):
 		signer = NewCancunSigner(config.ChainID)
 	case config.IsLondon(blockNumber):

--- a/core/types/tx_vector_fee.go
+++ b/core/types/tx_vector_fee.go
@@ -98,11 +98,22 @@ func (tx *VectorFeeTx) blobGas() uint64 {
 	return params.BlobTxBlobGasPerBlob * uint64(len(tx.BlobHashes))
 }
 
-// TODO: check if this is indeed proper implemenation
+// TODO: check if this is indeed proper implementation
 // NOTE: These methods are needed to satisfy TxData Interface
-func (tx *VectorFeeTx) gasFeeCap() *big.Int                                       { return nil }
-func (tx *VectorFeeTx) gasTipCap() *big.Int                                       { return nil }
-func (tx *VectorFeeTx) gasPrice() *big.Int                                        { return nil }
+func (tx *VectorFeeTx) gasFeeCap() *big.Int {
+	if s, err := tx.GasFeeCaps.ToVectorBigInt().Sum(); err == nil {
+		return s
+	}
+	return nil
+}
+
+func (tx *VectorFeeTx) gasTipCap() *big.Int {
+	if s, err := tx.GasTipCaps.ToVectorBigInt().Sum(); err == nil {
+		return s
+	}
+	return nil
+}
+func (tx *VectorFeeTx) gasPrice() *big.Int                                        { return tx.gasFeeCap() }
 func (tx *VectorFeeTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int { return nil }
 
 func (tx *VectorFeeTx) copy() TxData {

--- a/core/types/vector_fee.go
+++ b/core/types/vector_fee.go
@@ -245,3 +245,12 @@ func (vec VectorGasLimit) VectorSubtractClampAtZero(other VectorGasLimit) Vector
 	}
 	return result
 }
+
+// ToVectorBigInt converts a VectorFeeUint to VectorFeeBigint.
+func (vec VectorFeeUint) ToVectorBigInt() VectorFeeBigint {
+	result := make(VectorFeeBigint, VectorFeeTypesCount)
+	for i, v := range vec {
+		result[i] = v.ToBig()
+	}
+	return result
+}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -874,8 +874,6 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 		return api.delayPayloadImport(block), nil
 	}
 
-	//TODO: [rollup-geth] calculate BaseFees for EIP-7706 block
-
 	// We have an existing parent, do some sanity checks to avoid the beacon client
 	// triggering too early
 	var (

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -310,6 +310,10 @@ func (miner *Miner) applyTransaction(env *environment, tx *types.Transaction) (*
 		env.state.RevertToSnapshot(snap)
 		env.gasPool.SetGas(gp)
 	}
+
+	//[rollup-geth] EIP-7706
+	env.header.GasUsedVector = receipt.GasUsedVector
+
 	return receipt, err
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -426,7 +426,6 @@ func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment) 
 		MinTip: uint256.MustFromBig(tip),
 	}
 
-	//TODO: [rollup-geth] this is used for fetching TXs from the pool, we don't have yet defined rules for multi-dimensional fee ordering
 	if env.header.BaseFee != nil {
 		filter.BaseFee = uint256.MustFromBig(env.header.BaseFee)
 	}
@@ -470,6 +469,14 @@ func (miner *Miner) fillTransactions(interrupt *atomic.Int32, env *environment) 
 			return err
 		}
 	}
+
+	//[rollup-geth] EIP-7706
+	filter.OnlyVectorFeeTxs, filter.OnlyPlainTxs, filter.OnlyBlobTxs = true, false, false
+	pendingVectorTxs := miner.txpool.Pending(filter)
+	if err := miner.commitVectorFeeTransactions(env, pendingVectorTxs, interrupt); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -312,7 +312,9 @@ func (miner *Miner) applyTransaction(env *environment, tx *types.Transaction) (*
 	}
 
 	//[rollup-geth] EIP-7706
-	env.header.GasUsedVector = receipt.GasUsedVector
+	if miner.chainConfig.IsEIP7706(env.header.Number, env.header.Time) {
+		env.header.GasUsedVector = receipt.GasUsedVector
+	}
 
 	return receipt, err
 }

--- a/miner/worker_rollup.go
+++ b/miner/worker_rollup.go
@@ -1,0 +1,91 @@
+package miner
+
+import (
+	"errors"
+	"slices"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func (miner *Miner) commitVectorFeeTransactions(env *environment, txsByAddress map[common.Address][]*txpool.LazyTransaction, interrupt *atomic.Int32) error {
+	txs := sortTxsByNonces(txsByAddress)
+	if len(txs) == 0 {
+		return nil
+	}
+
+	gasLimit := env.header.GasLimit
+	if env.gasPool == nil {
+		env.gasPool = new(core.GasPool).AddGas(gasLimit)
+	}
+
+	for _, tx := range txs {
+		// Check interruption signal and abort building if it's fired.
+		if interrupt != nil {
+			if signal := interrupt.Load(); signal != commitInterruptNone {
+				return signalToErr(signal)
+			}
+		}
+		// If we don't have enough gas for any further transactions then we're done.
+		if env.gasPool.Gas() < params.TxGas {
+			log.Trace("Not enough gas for further transactions", "have", env.gasPool, "want", params.TxGas)
+			break
+		}
+		// Retrieve the next transaction and abort if all done.
+
+		// If we don't have enough space for the next transaction, skip the account.
+		if env.gasPool.Gas() < tx.Gas() {
+			log.Trace("Not enough gas left for transaction", "hash", tx.Hash, "left", env.gasPool.Gas(), "needed", tx.Gas())
+			continue
+		}
+
+		// Check whether the tx is replay protected. If we're not in the EIP155 hf
+		// phase, start ignoring the sender until we do.
+		if tx.Protected() && !miner.chainConfig.IsEIP155(env.header.Number) {
+			log.Trace("Ignoring replay protected transaction", "hash", tx.Hash, "eip155", miner.chainConfig.EIP155Block)
+			continue
+		}
+
+		// Error may be ignored here. The error has already been checked
+		// during transaction acceptance in the transaction pool.
+		from, _ := types.Sender(env.signer, tx)
+
+		// Start executing the transaction
+		env.state.SetTxContext(tx.Hash(), env.tcount)
+
+		err := miner.commitTransaction(env, tx)
+		switch {
+		case errors.Is(err, core.ErrNonceTooLow):
+			// New head notification data race between the transaction pool and miner, shift
+			log.Trace("Skipping transaction with low nonce", "hash", tx.Hash, "sender", from, "nonce", tx.Nonce())
+		default:
+			log.Debug("Transaction failed, account skipped", "hash", tx.Hash, "err", err)
+		}
+	}
+
+	return nil
+}
+
+func sortTxsByNonces(txs map[common.Address][]*txpool.LazyTransaction) types.Transactions {
+	txsSorted := make(types.Transactions, 0, len(txs))
+	// flatten and load lazy-loaded tx
+	for _, txsFromAddress := range txs {
+		for _, lazyTx := range txsFromAddress {
+			tx := lazyTx.Resolve()
+			if tx != nil {
+				txsSorted = append(txsSorted, tx)
+			}
+		}
+	}
+
+	slices.SortFunc(txsSorted, func(a, b *types.Transaction) int {
+		return int(a.Nonce()) - int(b.Nonce())
+	})
+
+	return txsSorted
+}

--- a/miner/worker_rollup.go
+++ b/miner/worker_rollup.go
@@ -51,20 +51,12 @@ func (miner *Miner) commitVectorFeeTransactions(env *environment, txsByAddress m
 			continue
 		}
 
-		// Error may be ignored here. The error has already been checked
-		// during transaction acceptance in the transaction pool.
-		from, _ := types.Sender(env.signer, tx)
-
 		// Start executing the transaction
 		env.state.SetTxContext(tx.Hash(), env.tcount)
 
 		err := miner.commitTransaction(env, tx)
-		switch {
-		case errors.Is(err, core.ErrNonceTooLow):
-			// New head notification data race between the transaction pool and miner, shift
-			log.Trace("Skipping transaction with low nonce", "hash", tx.Hash, "sender", from, "nonce", tx.Nonce())
-		default:
-			log.Debug("Transaction failed, account skipped", "hash", tx.Hash, "err", err)
+		if err != nil {
+			log.Error("[EIP-7706] Transaction failed, account skipped", "hash", tx.Hash, "err", err)
 		}
 	}
 

--- a/miner/worker_rollup.go
+++ b/miner/worker_rollup.go
@@ -1,7 +1,6 @@
 package miner
 
 import (
-	"errors"
 	"slices"
 	"sync/atomic"
 

--- a/params/config.go
+++ b/params/config.go
@@ -160,6 +160,9 @@ var (
 		CancunTime:                    newUint64(0),
 		TerminalTotalDifficulty:       big.NewInt(0),
 		TerminalTotalDifficultyPassed: true,
+
+		//[roolup-geth] EIP-7706
+		EIP7706Time: newUint64(0),
 	}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced

--- a/params/config.go
+++ b/params/config.go
@@ -160,9 +160,6 @@ var (
 		CancunTime:                    newUint64(0),
 		TerminalTotalDifficulty:       big.NewInt(0),
 		TerminalTotalDifficultyPassed: true,
-
-		//[roolup-geth] EIP-7706
-		EIP7706Time: newUint64(0),
 	}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced

--- a/params/config_rollup.go
+++ b/params/config_rollup.go
@@ -2,6 +2,30 @@ package params
 
 import "math/big"
 
+var AllRollupDevChainProtocolChanges = &ChainConfig{
+	ChainID:                       big.NewInt(1337),
+	HomesteadBlock:                big.NewInt(0),
+	EIP150Block:                   big.NewInt(0),
+	EIP155Block:                   big.NewInt(0),
+	EIP158Block:                   big.NewInt(0),
+	ByzantiumBlock:                big.NewInt(0),
+	ConstantinopleBlock:           big.NewInt(0),
+	PetersburgBlock:               big.NewInt(0),
+	IstanbulBlock:                 big.NewInt(0),
+	MuirGlacierBlock:              big.NewInt(0),
+	BerlinBlock:                   big.NewInt(0),
+	LondonBlock:                   big.NewInt(0),
+	ArrowGlacierBlock:             big.NewInt(0),
+	GrayGlacierBlock:              big.NewInt(0),
+	ShanghaiTime:                  newUint64(0),
+	CancunTime:                    newUint64(0),
+	TerminalTotalDifficulty:       big.NewInt(0),
+	TerminalTotalDifficultyPassed: true,
+
+	//[rollup-geth] EIP-7706
+	EIP7706Time: newUint64(0),
+}
+
 // IsEIP4762 returns whether eip 4762 has been activated at given block.
 func (c *ChainConfig) IsEIP7706(num *big.Int, time uint64) bool {
 	return isTimestampForked(c.EIP7706Time, time)


### PR DESCRIPTION
This is the fifth PR tackling #12  ([EIP-7706](https://eips.ethereum.org/EIPS/eip-7706))

The main purpose of this PR is to enable processing and block-inclusion of the new EIP-7706 type of transaction (`tx_vector_fee`).

**IMPORTANT**
Similarly to the previous PR (tx pool #16), the changes to the miner are just to have basic implementation which we can test. This is most obvious in the way I implemented txs ordering - they are just sorted by `nonce` and that's it (unlike the official implementation which sorts by gas, nonce and time). 

### Receipts
I've updated the `core/types/receipts` to hold the vector of the `GasUsed` (`[execution, blob, calldata]`) - this was modelled by how `BlobGasUsed` was handled.

### Bugfixes
The PR also contains bunch of small bugfixes discovered during manual testing.
But, the good news is that we can now:
1. Sing and send transaction using client connected to the `geth --dev` node.
2. This TX will be included by miner that will produce `EIP-7706` block. 
3. The block will be successfully sent & received by `engineApi`
4. The block will be successfully validated and re-executed