### PR TITLE
Implement EIP-2970 with ISSTATIC opcode and related tests

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -323,6 +323,26 @@ func enable6780(jt *JumpTable) {
 	}
 }
 
+// opIsStatic implements the ISSTATIC opcode
+func opIsStatic(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	if interpreter.readOnly {
+		scope.Stack.push(uint256.NewInt(1))
+	} else {
+		scope.Stack.push(uint256.NewInt(0))
+	}
+	return nil, nil
+}
+
+// enable2970 applies EIP-2970 (ISSTATIC opcode)  https://eips.ethereum.org/EIPS/eip-2970
+func enable2970(jt *JumpTable) {
+	jt[ISSTATIC] = &operation{
+		execute:     opIsStatic,
+		constantGas: GasQuickStep,
+		minStack:    minStack(0, 1),
+		maxStack:    maxStack(0, 1),
+	}
+}
+
 func opExtCodeCopyEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	var (
 		stack      = scope.Stack

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -108,6 +108,7 @@ func newCancunInstructionSet() JumpTable {
 	enable1153(&instructionSet) // EIP-1153 "Transient Storage"
 	enable5656(&instructionSet) // EIP-5656 (MCOPY opcode)
 	enable6780(&instructionSet) // EIP-6780 SELFDESTRUCT only in same transaction
+	enable2970(&instructionSet) // EIP-2970 (ISSTATIC opcode) https://eips.ethereum.org/EIPS/eip-2970
 	return validate(instructionSet)
 }
 

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -104,6 +104,7 @@ const (
 	BASEFEE     OpCode = 0x48
 	BLOBHASH    OpCode = 0x49
 	BLOBBASEFEE OpCode = 0x4a
+	ISSTATIC    OpCode = 0x4b // To determine if the current context is static or not, as described at https://eips.ethereum.org/EIPS/eip-2970
 )
 
 // 0x50 range - 'storage' and execution.
@@ -318,6 +319,7 @@ var opCodeToString = [256]string{
 	BASEFEE:     "BASEFEE",
 	BLOBHASH:    "BLOBHASH",
 	BLOBBASEFEE: "BLOBBASEFEE",
+	ISSTATIC:    "ISSTATIC",
 
 	// 0x50 range - 'storage' and execution.
 	POP:      "POP",
@@ -499,6 +501,7 @@ var stringToOp = map[string]OpCode{
 	"BASEFEE":         BASEFEE,
 	"BLOBHASH":        BLOBHASH,
 	"BLOBBASEFEE":     BLOBBASEFEE,
+	"ISSTATIC":        ISSTATIC,
 	"DELEGATECALL":    DELEGATECALL,
 	"STATICCALL":      STATICCALL,
 	"CODESIZE":        CODESIZE,


### PR DESCRIPTION
This PR implements [EIP-2970](https://eips.ethereum.org/EIPS/eip-2970).

Few caveats to know before reviewing:

- The EIP specifies `0x4a` as the bytecode for this new opcode. However, since this EIP is four years old, `0x4a` has already been taken. Therefore, I have assigned `0x4b`, which is still available within the same bytecode range.
- For the purpose of this PR, I have enabled this opcode in the Cancun hard fork. However, in reality, newly added EIPs are likely to be included in a future, yet-to-be-released hard fork -- currently expected to be **Prague**.
- At the moment, there is only one test that verifies `ISSTATIC` correctly returns `true` when called inside `staticcall`. I am working on an additional test to ensure it correctly returns `false` in otherwise scenario.
